### PR TITLE
refactor WeeklyAiAnalysis 엔티티 필드 구조 변경

### DIFF
--- a/src/main/java/com/omteam/omt/report/domain/WeeklyAiAnalysis.java
+++ b/src/main/java/com/omteam/omt/report/domain/WeeklyAiAnalysis.java
@@ -1,0 +1,53 @@
+package com.omteam.omt.report.domain;
+
+import com.omteam.omt.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "weekly_ai_analysis")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class WeeklyAiAnalysis {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDate weekStartDate;
+
+    @Column(length = 200)
+    private String mainFailureReason;
+
+    @Column(length = 500)
+    private String overallFeedback;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/omteam/omt/report/repository/WeeklyAiAnalysisRepository.java
+++ b/src/main/java/com/omteam/omt/report/repository/WeeklyAiAnalysisRepository.java
@@ -1,0 +1,11 @@
+package com.omteam.omt.report.repository;
+
+import com.omteam.omt.report.domain.WeeklyAiAnalysis;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeeklyAiAnalysisRepository extends JpaRepository<WeeklyAiAnalysis, Long> {
+
+    Optional<WeeklyAiAnalysis> findByUserUserIdAndWeekStartDate(Long userId, LocalDate weekStartDate);
+}

--- a/src/test/java/com/omteam/omt/report/domain/WeeklyAiAnalysisTest.java
+++ b/src/test/java/com/omteam/omt/report/domain/WeeklyAiAnalysisTest.java
@@ -1,0 +1,123 @@
+package com.omteam.omt.report.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.omteam.omt.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WeeklyAiAnalysisTest {
+
+    @Test
+    @DisplayName("Builder로 엔티티 생성 시 모든 필드가 올바르게 설정된다")
+    void builder_creates_entity_with_all_fields() {
+        // given
+        User user = createUser();
+        LocalDate weekStartDate = LocalDate.of(2024, 1, 15);
+        String mainFailureReason = "시간 부족";
+        String overallFeedback = "이번 주는 업무가 많아 운동 시간 확보가 어려웠습니다.";
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        // when
+        WeeklyAiAnalysis analysis = WeeklyAiAnalysis.builder()
+                .id(1L)
+                .user(user)
+                .weekStartDate(weekStartDate)
+                .mainFailureReason(mainFailureReason)
+                .overallFeedback(overallFeedback)
+                .createdAt(createdAt)
+                .build();
+
+        // then
+        assertThat(analysis.getId()).isEqualTo(1L);
+        assertThat(analysis.getUser()).isEqualTo(user);
+        assertThat(analysis.getWeekStartDate()).isEqualTo(weekStartDate);
+        assertThat(analysis.getMainFailureReason()).isEqualTo(mainFailureReason);
+        assertThat(analysis.getOverallFeedback()).isEqualTo(overallFeedback);
+        assertThat(analysis.getCreatedAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    @DisplayName("mainFailureReason 필드는 null일 수 있다")
+    void mainFailureReason_can_be_null() {
+        // given
+        User user = createUser();
+        LocalDate weekStartDate = LocalDate.of(2024, 1, 15);
+
+        // when
+        WeeklyAiAnalysis analysis = WeeklyAiAnalysis.builder()
+                .user(user)
+                .weekStartDate(weekStartDate)
+                .mainFailureReason(null)
+                .overallFeedback("피드백")
+                .build();
+
+        // then
+        assertThat(analysis.getMainFailureReason()).isNull();
+    }
+
+    @Test
+    @DisplayName("overallFeedback 필드는 null일 수 있다")
+    void overallFeedback_can_be_null() {
+        // given
+        User user = createUser();
+        LocalDate weekStartDate = LocalDate.of(2024, 1, 15);
+
+        // when
+        WeeklyAiAnalysis analysis = WeeklyAiAnalysis.builder()
+                .user(user)
+                .weekStartDate(weekStartDate)
+                .mainFailureReason("실패 원인")
+                .overallFeedback(null)
+                .build();
+
+        // then
+        assertThat(analysis.getOverallFeedback()).isNull();
+    }
+
+    @Test
+    @DisplayName("mainFailureReason 최대 길이 200자까지 저장 가능")
+    void mainFailureReason_max_length_200() {
+        // given
+        User user = createUser();
+        String longReason = "a".repeat(200);
+
+        // when
+        WeeklyAiAnalysis analysis = WeeklyAiAnalysis.builder()
+                .user(user)
+                .weekStartDate(LocalDate.now())
+                .mainFailureReason(longReason)
+                .build();
+
+        // then
+        assertThat(analysis.getMainFailureReason()).hasSize(200);
+    }
+
+    @Test
+    @DisplayName("overallFeedback 최대 길이 500자까지 저장 가능")
+    void overallFeedback_max_length_500() {
+        // given
+        User user = createUser();
+        String longFeedback = "b".repeat(500);
+
+        // when
+        WeeklyAiAnalysis analysis = WeeklyAiAnalysis.builder()
+                .user(user)
+                .weekStartDate(LocalDate.now())
+                .overallFeedback(longFeedback)
+                .build();
+
+        // then
+        assertThat(analysis.getOverallFeedback()).hasSize(500);
+    }
+
+    private User createUser() {
+        return User.builder()
+                .userId(1L)
+                .email("test@example.com")
+                .nickname("테스트유저")
+                .build();
+    }
+}

--- a/src/test/java/com/omteam/omt/report/repository/WeeklyAiAnalysisRepositoryTest.java
+++ b/src/test/java/com/omteam/omt/report/repository/WeeklyAiAnalysisRepositoryTest.java
@@ -1,0 +1,159 @@
+package com.omteam.omt.report.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.omteam.omt.report.domain.WeeklyAiAnalysis;
+import com.omteam.omt.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyAiAnalysisRepositoryTest {
+
+    @Mock
+    WeeklyAiAnalysisRepository weeklyAiAnalysisRepository;
+
+    User testUser;
+    WeeklyAiAnalysis testAnalysis;
+    final LocalDate weekStartDate = LocalDate.of(2024, 1, 15);
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .userId(1L)
+                .email("test@example.com")
+                .nickname("테스트유저")
+                .build();
+
+        testAnalysis = WeeklyAiAnalysis.builder()
+                .id(1L)
+                .user(testUser)
+                .weekStartDate(weekStartDate)
+                .mainFailureReason("시간 부족")
+                .overallFeedback("이번 주 피드백입니다.")
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("엔티티 저장 성공")
+    void save_success() {
+        // given
+        given(weeklyAiAnalysisRepository.save(any(WeeklyAiAnalysis.class)))
+                .willReturn(testAnalysis);
+
+        WeeklyAiAnalysis toSave = WeeklyAiAnalysis.builder()
+                .user(testUser)
+                .weekStartDate(weekStartDate)
+                .mainFailureReason("시간 부족")
+                .overallFeedback("이번 주 피드백입니다.")
+                .build();
+
+        // when
+        WeeklyAiAnalysis saved = weeklyAiAnalysisRepository.save(toSave);
+
+        // then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getUser().getUserId()).isEqualTo(testUser.getUserId());
+        assertThat(saved.getWeekStartDate()).isEqualTo(weekStartDate);
+        assertThat(saved.getMainFailureReason()).isEqualTo("시간 부족");
+        assertThat(saved.getOverallFeedback()).isEqualTo("이번 주 피드백입니다.");
+    }
+
+    @Test
+    @DisplayName("ID로 조회 성공")
+    void findById_success() {
+        // given
+        given(weeklyAiAnalysisRepository.findById(1L))
+                .willReturn(Optional.of(testAnalysis));
+
+        // when
+        Optional<WeeklyAiAnalysis> found = weeklyAiAnalysisRepository.findById(1L);
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("userId와 weekStartDate로 조회 성공")
+    void findByUserUserIdAndWeekStartDate_success() {
+        // given
+        given(weeklyAiAnalysisRepository.findByUserUserIdAndWeekStartDate(1L, weekStartDate))
+                .willReturn(Optional.of(testAnalysis));
+
+        // when
+        Optional<WeeklyAiAnalysis> found = weeklyAiAnalysisRepository
+                .findByUserUserIdAndWeekStartDate(1L, weekStartDate);
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getUser().getUserId()).isEqualTo(1L);
+        assertThat(found.get().getWeekStartDate()).isEqualTo(weekStartDate);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 userId로 조회 시 empty 반환")
+    void findByUserUserIdAndWeekStartDate_notFoundByUserId() {
+        // given
+        Long nonExistentUserId = 99999L;
+        given(weeklyAiAnalysisRepository.findByUserUserIdAndWeekStartDate(nonExistentUserId, weekStartDate))
+                .willReturn(Optional.empty());
+
+        // when
+        Optional<WeeklyAiAnalysis> found = weeklyAiAnalysisRepository
+                .findByUserUserIdAndWeekStartDate(nonExistentUserId, weekStartDate);
+
+        // then
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 weekStartDate로 조회 시 empty 반환")
+    void findByUserUserIdAndWeekStartDate_notFoundByWeekStartDate() {
+        // given
+        LocalDate differentWeekStartDate = LocalDate.of(2024, 1, 22);
+        given(weeklyAiAnalysisRepository.findByUserUserIdAndWeekStartDate(1L, differentWeekStartDate))
+                .willReturn(Optional.empty());
+
+        // when
+        Optional<WeeklyAiAnalysis> found = weeklyAiAnalysisRepository
+                .findByUserUserIdAndWeekStartDate(1L, differentWeekStartDate);
+
+        // then
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("mainFailureReason과 overallFeedback이 null인 경우에도 조회 성공")
+    void findById_with_null_optional_fields() {
+        // given
+        WeeklyAiAnalysis analysisWithNulls = WeeklyAiAnalysis.builder()
+                .id(2L)
+                .user(testUser)
+                .weekStartDate(weekStartDate)
+                .mainFailureReason(null)
+                .overallFeedback(null)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        given(weeklyAiAnalysisRepository.findById(2L))
+                .willReturn(Optional.of(analysisWithNulls));
+
+        // when
+        Optional<WeeklyAiAnalysis> found = weeklyAiAnalysisRepository.findById(2L);
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getMainFailureReason()).isNull();
+        assertThat(found.get().getOverallFeedback()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- WeeklyAiAnalysis 엔티티 생성 (신규 필드 구조: mainFailureReason, overallFeedback)
- WeeklyAiAnalysisRepository 인터페이스 생성
- 엔티티 및 Repository 단위 테스트 추가 (총 11개 테스트 케이스)

## 변경 사항
### 신규 파일
- `src/main/java/com/omteam/omt/report/domain/WeeklyAiAnalysis.java`
  - 주간 AI 분석 결과 엔티티
  - 필드: id, user, weekStartDate, mainFailureReason(200자), overallFeedback(500자), createdAt
- `src/main/java/com/omteam/omt/report/repository/WeeklyAiAnalysisRepository.java`
  - JpaRepository 상속
  - `findByUserUserIdAndWeekStartDate()` 커스텀 메서드 포함

### 테스트
- `WeeklyAiAnalysisTest`: 엔티티 생성 및 필드 검증 테스트 (5개)
- `WeeklyAiAnalysisRepositoryTest`: Repository 메서드 테스트 (6개)

## Test plan
- [x] `./gradlew build` 성공
- [x] `./gradlew test` 전체 테스트 통과
- [x] WeeklyAiAnalysis 관련 테스트 11개 통과

Resolves #18

🤖 Generated with [Claude Code](https://claude.ai/code)