### PR TITLE
[REFACTOR] DailyAnalysis 관련 클래스를 report 패키지로 이동 #34

### DIFF
--- a/src/main/java/com/omteam/omt/character/service/CharacterService.java
+++ b/src/main/java/com/omteam/omt/character/service/CharacterService.java
@@ -1,10 +1,10 @@
 package com.omteam.omt.character.service;
 
-import com.omteam.omt.character.domain.DailyAnalysis;
-import com.omteam.omt.character.domain.EncouragementIntent;
-import com.omteam.omt.character.domain.EncouragementMessage;
 import com.omteam.omt.character.dto.CharacterResponse;
-import com.omteam.omt.character.repository.DailyAnalysisRepository;
+import com.omteam.omt.report.domain.DailyAnalysis;
+import com.omteam.omt.report.domain.EncouragementIntent;
+import com.omteam.omt.report.domain.EncouragementMessage;
+import com.omteam.omt.report.repository.DailyAnalysisRepository;
 import com.omteam.omt.common.exception.BusinessException;
 import com.omteam.omt.common.exception.ErrorCode;
 import com.omteam.omt.mission.domain.DailyMissionResult;

--- a/src/main/java/com/omteam/omt/report/client/AiDailyAnalysisClient.java
+++ b/src/main/java/com/omteam/omt/report/client/AiDailyAnalysisClient.java
@@ -1,7 +1,7 @@
-package com.omteam.omt.character.client;
+package com.omteam.omt.report.client;
 
-import com.omteam.omt.character.client.dto.AiDailyAnalysisRequest;
-import com.omteam.omt.character.client.dto.AiDailyAnalysisResponse;
+import com.omteam.omt.report.client.dto.AiDailyAnalysisRequest;
+import com.omteam.omt.report.client.dto.AiDailyAnalysisResponse;
 import com.omteam.omt.common.exception.BusinessException;
 import com.omteam.omt.common.exception.ErrorCode;
 import com.omteam.omt.config.properties.AiServerProperties;

--- a/src/main/java/com/omteam/omt/report/client/dto/AiDailyAnalysisRequest.java
+++ b/src/main/java/com/omteam/omt/report/client/dto/AiDailyAnalysisRequest.java
@@ -1,4 +1,4 @@
-package com.omteam.omt.character.client.dto;
+package com.omteam.omt.report.client.dto;
 
 import com.omteam.omt.mission.domain.MissionResult;
 import com.omteam.omt.mission.domain.MissionType;

--- a/src/main/java/com/omteam/omt/report/client/dto/AiDailyAnalysisResponse.java
+++ b/src/main/java/com/omteam/omt/report/client/dto/AiDailyAnalysisResponse.java
@@ -1,6 +1,6 @@
-package com.omteam.omt.character.client.dto;
+package com.omteam.omt.report.client.dto;
 
-import com.omteam.omt.character.domain.EncouragementIntent;
+import com.omteam.omt.report.domain.EncouragementIntent;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/omteam/omt/report/client/dto/EncouragementCandidate.java
+++ b/src/main/java/com/omteam/omt/report/client/dto/EncouragementCandidate.java
@@ -1,6 +1,6 @@
-package com.omteam.omt.character.client.dto;
+package com.omteam.omt.report.client.dto;
 
-import com.omteam.omt.character.domain.EncouragementIntent;
+import com.omteam.omt.report.domain.EncouragementIntent;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/omteam/omt/report/domain/DailyAnalysis.java
+++ b/src/main/java/com/omteam/omt/report/domain/DailyAnalysis.java
@@ -1,4 +1,4 @@
-package com.omteam.omt.character.domain;
+package com.omteam.omt.report.domain;
 
 import com.omteam.omt.user.domain.User;
 import jakarta.persistence.AttributeOverride;

--- a/src/main/java/com/omteam/omt/report/domain/EncouragementIntent.java
+++ b/src/main/java/com/omteam/omt/report/domain/EncouragementIntent.java
@@ -1,4 +1,4 @@
-package com.omteam.omt.character.domain;
+package com.omteam.omt.report.domain;
 
 /**
  * 격려 메시지 의도 유형

--- a/src/main/java/com/omteam/omt/report/domain/EncouragementMessage.java
+++ b/src/main/java/com/omteam/omt/report/domain/EncouragementMessage.java
@@ -1,4 +1,4 @@
-package com.omteam.omt.character.domain;
+package com.omteam.omt.report.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/src/main/java/com/omteam/omt/report/repository/DailyAnalysisRepository.java
+++ b/src/main/java/com/omteam/omt/report/repository/DailyAnalysisRepository.java
@@ -1,6 +1,6 @@
-package com.omteam.omt.character.repository;
+package com.omteam.omt.report.repository;
 
-import com.omteam.omt.character.domain.DailyAnalysis;
+import com.omteam.omt.report.domain.DailyAnalysis;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/omteam/omt/report/scheduler/DailyAnalysisScheduler.java
+++ b/src/main/java/com/omteam/omt/report/scheduler/DailyAnalysisScheduler.java
@@ -1,6 +1,6 @@
-package com.omteam.omt.character.scheduler;
+package com.omteam.omt.report.scheduler;
 
-import com.omteam.omt.character.service.DailyAnalysisService;
+import com.omteam.omt.report.service.DailyAnalysisService;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/omteam/omt/report/service/DailyAnalysisService.java
+++ b/src/main/java/com/omteam/omt/report/service/DailyAnalysisService.java
@@ -1,13 +1,13 @@
-package com.omteam.omt.character.service;
+package com.omteam.omt.report.service;
 
-import com.omteam.omt.character.client.AiDailyAnalysisClient;
-import com.omteam.omt.character.client.dto.AiDailyAnalysisRequest;
-import com.omteam.omt.character.client.dto.AiDailyAnalysisResponse;
-import com.omteam.omt.character.client.dto.EncouragementCandidate;
-import com.omteam.omt.character.domain.DailyAnalysis;
-import com.omteam.omt.character.domain.EncouragementIntent;
-import com.omteam.omt.character.domain.EncouragementMessage;
-import com.omteam.omt.character.repository.DailyAnalysisRepository;
+import com.omteam.omt.report.client.AiDailyAnalysisClient;
+import com.omteam.omt.report.client.dto.AiDailyAnalysisRequest;
+import com.omteam.omt.report.client.dto.AiDailyAnalysisResponse;
+import com.omteam.omt.report.client.dto.EncouragementCandidate;
+import com.omteam.omt.report.domain.DailyAnalysis;
+import com.omteam.omt.report.domain.EncouragementIntent;
+import com.omteam.omt.report.domain.EncouragementMessage;
+import com.omteam.omt.report.repository.DailyAnalysisRepository;
 import com.omteam.omt.mission.domain.DailyMissionResult;
 import com.omteam.omt.mission.repository.DailyMissionResultRepository;
 import com.omteam.omt.user.domain.User;
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DailyAnalysisService {
 
     private final AiDailyAnalysisClient aiDailyAnalysisClient;
-    private final DailyAnalysisRepository DailyAnalysisRepository;
+    private final DailyAnalysisRepository dailyAnalysisRepository;
     private final DailyMissionResultRepository missionResultRepository;
     private final UserRepository userRepository;
 
@@ -56,7 +56,7 @@ public class DailyAnalysisService {
      */
     @Transactional
     public void generateDailyAnalysisForUser(User user, LocalDate targetDate) {
-        if (DailyAnalysisRepository.existsByUserUserIdAndTargetDate(user.getUserId(), targetDate)) {
+        if (dailyAnalysisRepository.existsByUserUserIdAndTargetDate(user.getUserId(), targetDate)) {
             log.debug("이미 분석 결과가 존재함: userId={}, targetDate={}", user.getUserId(), targetDate);
             return;
         }
@@ -70,7 +70,7 @@ public class DailyAnalysisService {
         AiDailyAnalysisResponse response = aiDailyAnalysisClient.requestDailyAnalysis(request);
 
         DailyAnalysis dailyAnalysis = buildDailyAnalysis(user, targetDate, response);
-        DailyAnalysisRepository.save(dailyAnalysis);
+        dailyAnalysisRepository.save(dailyAnalysis);
 
         log.info("데일리 분석 결과 생성 완료: userId={}, targetDate={}", user.getUserId(), targetDate);
     }

--- a/src/test/java/com/omteam/omt/character/service/CharacterServiceTest.java
+++ b/src/test/java/com/omteam/omt/character/service/CharacterServiceTest.java
@@ -3,10 +3,10 @@ package com.omteam.omt.character.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import com.omteam.omt.character.domain.DailyAnalysis;
-import com.omteam.omt.character.domain.EncouragementMessage;
 import com.omteam.omt.character.dto.CharacterResponse;
-import com.omteam.omt.character.repository.DailyAnalysisRepository;
+import com.omteam.omt.report.domain.DailyAnalysis;
+import com.omteam.omt.report.domain.EncouragementMessage;
+import com.omteam.omt.report.repository.DailyAnalysisRepository;
 import com.omteam.omt.common.exception.BusinessException;
 import com.omteam.omt.common.exception.ErrorCode;
 import com.omteam.omt.mission.domain.DailyMissionResult;

--- a/src/test/java/com/omteam/omt/integration/report/AiDailyAnalysisClientIntegrationTest.java
+++ b/src/test/java/com/omteam/omt/integration/report/AiDailyAnalysisClientIntegrationTest.java
@@ -1,11 +1,11 @@
-package com.omteam.omt.integration.character;
+package com.omteam.omt.integration.report;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.omteam.omt.character.client.AiDailyAnalysisClient;
-import com.omteam.omt.character.client.dto.AiDailyAnalysisRequest;
-import com.omteam.omt.character.client.dto.AiDailyAnalysisResponse;
-import com.omteam.omt.character.domain.EncouragementIntent;
+import com.omteam.omt.report.client.AiDailyAnalysisClient;
+import com.omteam.omt.report.client.dto.AiDailyAnalysisRequest;
+import com.omteam.omt.report.client.dto.AiDailyAnalysisResponse;
+import com.omteam.omt.report.domain.EncouragementIntent;
 import com.omteam.omt.common.exception.BusinessException;
 import com.omteam.omt.common.exception.ErrorCode;
 import com.omteam.omt.integration.IntegrationTestBase;

--- a/src/test/java/com/omteam/omt/integration/report/DailyAnalysisServiceIntegrationTest.java
+++ b/src/test/java/com/omteam/omt/integration/report/DailyAnalysisServiceIntegrationTest.java
@@ -1,11 +1,11 @@
-package com.omteam.omt.integration.character;
+package com.omteam.omt.integration.report;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.omteam.omt.character.domain.DailyAnalysis;
-import com.omteam.omt.character.domain.EncouragementIntent;
-import com.omteam.omt.character.repository.DailyAnalysisRepository;
-import com.omteam.omt.character.service.DailyAnalysisService;
+import com.omteam.omt.report.domain.DailyAnalysis;
+import com.omteam.omt.report.domain.EncouragementIntent;
+import com.omteam.omt.report.repository.DailyAnalysisRepository;
+import com.omteam.omt.report.service.DailyAnalysisService;
 import com.omteam.omt.integration.IntegrationTestBase;
 import com.omteam.omt.mission.domain.DailyMissionResult;
 import com.omteam.omt.mission.domain.Mission;


### PR DESCRIPTION
## Summary
- DailyAnalysis 관련 클래스를 character 패키지에서 report 패키지로 이동
- CharacterService는 character 패키지에 유지하고 import 경로만 업데이트
- 테스트 파일 패키지 경로 및 import 업데이트

## Changes
### character → report 패키지로 이동
- **domain**: `DailyAnalysis`, `EncouragementIntent`, `EncouragementMessage`
- **client**: `AiDailyAnalysisClient` 및 DTO (`AiDailyAnalysisRequest`, `AiDailyAnalysisResponse`, `EncouragementCandidate`)
- **repository**: `DailyAnalysisRepository`
- **service**: `DailyAnalysisService`
- **scheduler**: `DailyAnalysisScheduler`

### 유지된 파일 (import 경로만 변경)
- `CharacterService.java`
- `CharacterServiceTest.java`

### 테스트 파일 이동
- `integration/character/` → `integration/report/`

## Test plan
- [x] `./gradlew build` 성공
- [x] `./gradlew test` 모든 테스트 통과

closes #34