### PR TITLE
[FEAT] 챗봇 도메인 엔티티 및 Enum 구현

### DIFF
--- a/src/main/java/com/omteam/omt/chat/domain/ChatInputType.java
+++ b/src/main/java/com/omteam/omt/chat/domain/ChatInputType.java
@@ -1,0 +1,9 @@
+package com.omteam.omt.chat.domain;
+
+/**
+ * 챗봇 메시지 입력 타입
+ */
+public enum ChatInputType {
+    TEXT,    // 자유 텍스트 입력
+    OPTION   // 선택지 선택
+}

--- a/src/main/java/com/omteam/omt/chat/domain/ChatMessage.java
+++ b/src/main/java/com/omteam/omt/chat/domain/ChatMessage.java
@@ -1,0 +1,69 @@
+package com.omteam.omt.chat.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 챗봇 대화 메시지.
+ * 사용자 메시지와 AI 응답 메시지를 모두 저장한다.
+ */
+@Entity
+@Table(name = "chat_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private ChatSession session;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatMessageRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "input_type")
+    private ChatInputType inputType;  // USER 메시지에만 해당
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "selected_value")
+    private String selectedValue;  // OPTION 타입일 때 선택한 값
+
+    @Column(columnDefinition = "TEXT")
+    private String options;  // JSON: [{"label":"...", "value":"..."}]
+
+    @Column(name = "is_terminal", nullable = false)
+    @Builder.Default
+    private boolean isTerminal = false;  // 대화 종료 메시지 여부 (ASSISTANT만)
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/omteam/omt/chat/domain/ChatMessageRole.java
+++ b/src/main/java/com/omteam/omt/chat/domain/ChatMessageRole.java
@@ -1,0 +1,9 @@
+package com.omteam.omt.chat.domain;
+
+/**
+ * 챗봇 메시지 발신자 역할
+ */
+public enum ChatMessageRole {
+    USER,       // 사용자 메시지
+    ASSISTANT   // AI 봇 메시지
+}

--- a/src/main/java/com/omteam/omt/chat/domain/ChatSession.java
+++ b/src/main/java/com/omteam/omt/chat/domain/ChatSession.java
@@ -1,0 +1,63 @@
+package com.omteam.omt.chat.domain;
+
+import com.omteam.omt.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 챗봇 대화 세션.
+ * 사용자당 최대 1개의 활성 세션만 존재할 수 있다.
+ */
+@Entity
+@Table(name = "chat_session")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class ChatSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private boolean isActive = true;
+
+    @CreatedDate
+    @Column(name = "started_at", nullable = false, updatable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
+
+    /**
+     * 세션을 종료 처리한다.
+     * AI가 isTerminal을 반환했을 때 호출된다.
+     */
+    public void end() {
+        this.isActive = false;
+        this.endedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/omteam/omt/common/exception/ErrorCode.java
+++ b/src/main/java/com/omteam/omt/common/exception/ErrorCode.java
@@ -42,7 +42,11 @@ public enum ErrorCode {
 
     // AI Server (AI)
     AI_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "AI001", "AI 서버 응답 오류입니다"),
-    AI_SERVER_CONNECTION_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "AI002", "AI 서버 연결에 실패했습니다");
+    AI_SERVER_CONNECTION_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "AI002", "AI 서버 연결에 실패했습니다"),
+
+    // Chat (CH)
+    INVALID_CHAT_INPUT(HttpStatus.BAD_REQUEST, "CH001", "유효하지 않은 채팅 입력입니다"),
+    CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CH002", "채팅 세션을 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## Summary
- 챗봇 기능의 핵심 도메인 엔티티와 Enum 구현
- 세션 관리 및 메시지 저장을 위한 기반 구조 완성

## Changes
- `chat/domain/ChatInputType.java` - 입력 타입 Enum (TEXT, OPTION)
- `chat/domain/ChatMessageRole.java` - 발신자 역할 Enum (USER, ASSISTANT)
- `chat/domain/ChatSession.java` - 세션 엔티티
  - User 연관관계, isActive 플래그
  - end() 메서드로 세션 종료 처리
- `chat/domain/ChatMessage.java` - 메시지 엔티티
  - role, inputType, content, selectedValue 필드
  - options (JSON), isTerminal 플래그
- `common/exception/ErrorCode.java` - 챗봇 에러 코드 추가
  - INVALID_CHAT_INPUT (CH001)
  - CHAT_SESSION_NOT_FOUND (CH002)

## Test plan
- [x] 빌드 통과

Closes #40