### PR TITLE
[REFACTOR] startMission과 reselectMission 메서드 통합

### DIFF
--- a/src/main/java/com/omteam/omt/mission/controller/MissionController.java
+++ b/src/main/java/com/omteam/omt/mission/controller/MissionController.java
@@ -58,7 +58,8 @@ public class MissionController {
 
     @Operation(
             summary = "미션 시작",
-            description = "추천된 미션 중 하나를 선택하여 즉시 시작합니다."
+            description = "추천된 미션 중 하나를 선택하여 시작합니다. " +
+                    "진행 중인 미션이 있으면 자동으로 포기 처리 후 새 미션을 시작합니다."
     )
     @PostMapping("/daily/start")
     public ApiResponse<RecommendedMissionResponse> startMission(
@@ -67,20 +68,6 @@ public class MissionController {
     ) {
         return ApiResponse.success(
                 missionService.startMission(userPrincipal.userId(), request.getRecommendedMissionId())
-        );
-    }
-
-    @Operation(
-            summary = "미션 다시 선택",
-            description = "진행 중인 미션을 포기하고 다른 미션을 선택하여 즉시 시작합니다."
-    )
-    @PostMapping("/daily/reselect")
-    public ApiResponse<RecommendedMissionResponse> reselectMission(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @Valid @RequestBody MissionSelectRequest request
-    ) {
-        return ApiResponse.success(
-                missionService.reselectMission(userPrincipal.userId(), request.getRecommendedMissionId())
         );
     }
 

--- a/src/main/java/com/omteam/omt/mission/service/MissionService.java
+++ b/src/main/java/com/omteam/omt/mission/service/MissionService.java
@@ -73,43 +73,23 @@ public class MissionService {
                 .build();
     }
 
-    public RecommendedMissionResponse startMission(Long userId, Long recommendedMissionId) {
-        LocalDate today = LocalDate.now();
-
-        validateNoInProgressMission(userId, today);
-        validateNoMissionResultToday(userId, today);
-
-        DailyRecommendedMission recommendation = recommendedMissionRepository
-                .findByIdAndUserUserId(recommendedMissionId, userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MISSION_NOT_FOUND));
-
-        if (!recommendation.isStartable()) {
-            throw new BusinessException(ErrorCode.INVALID_MISSION_STATUS);
-        }
-
-        recommendation.start();
-        return RecommendedMissionResponse.from(recommendation);
-    }
-
-    public RecommendedMissionResponse reselectMission(Long userId, Long newMissionId) {
+    public RecommendedMissionResponse startMission(Long userId, Long missionId) {
         LocalDate today = LocalDate.now();
 
         validateNoMissionResultToday(userId, today);
 
-        // 새로 시작할 미션 조회
         DailyRecommendedMission newMission = recommendedMissionRepository
-                .findByIdAndUserUserId(newMissionId, userId)
+                .findByIdAndUserUserId(missionId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MISSION_NOT_FOUND));
 
         if (!newMission.isStartable()) {
             throw new BusinessException(ErrorCode.INVALID_MISSION_STATUS);
         }
 
-        // 진행 중인 미션 만료 처리 (포기)
+        // 진행 중인 미션이 있으면 자동 만료 처리
         findFirstMissionByStatus(userId, today, RecommendedMissionStatus.IN_PROGRESS)
                 .ifPresent(DailyRecommendedMission::expire);
 
-        // 새 미션 시작
         newMission.start();
         return RecommendedMissionResponse.from(newMission);
     }
@@ -308,12 +288,6 @@ public class MissionService {
 
     private Optional<DailyRecommendedMission> findFirstMissionByStatus(Long userId, LocalDate date, RecommendedMissionStatus status) {
         return findMissionsByStatus(userId, date, status).stream().findFirst();
-    }
-
-    private void validateNoInProgressMission(Long userId, LocalDate date) {
-        if (hasInProgressMission(userId, date)) {
-            throw new BusinessException(ErrorCode.MISSION_ALREADY_IN_PROGRESS);
-        }
     }
 
     private void validateNoMissionResultToday(Long userId, LocalDate date) {


### PR DESCRIPTION
## 개요
미션 시작 API 와 재시작 API를 하나로 통합하여 사용 복잡도를 감소시킵니다.

API 변경:
- POST /api/missions/daily/start: 진행 중 미션 있으면 자동 포기 후 새 미션 시작
- DELETE POST /api/missions/daily/reselect

## 관련 이슈
#11 

## 변경 내용
- MissionService.startMission이 진행 중인 미션 자동 만료 처리
- MissionService.reselectMission 메서드 제거
- MissionController에서 /daily/reselect API 제거
- validateNoInProgressMission 미사용 메서드 제거

## 확인 사항
- [x] 기능 정상 동작 확인