### PR TITLE
[FEAT] 주간 리포트 조회 파라미터 형식 개선

### DIFF
--- a/src/main/java/com/omteam/omt/common/exception/ErrorCode.java
+++ b/src/main/java/com/omteam/omt/common/exception/ErrorCode.java
@@ -49,7 +49,8 @@ public enum ErrorCode {
     CHAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CH002", "채팅 세션을 찾을 수 없습니다"),
 
     // Report (R)
-    DAILY_FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "해당 날짜의 피드백을 찾을 수 없습니다");
+    DAILY_FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "해당 날짜의 피드백을 찾을 수 없습니다"),
+    INVALID_WEEK_OF_MONTH(HttpStatus.BAD_REQUEST, "R002", "해당 월에 존재하지 않는 주차입니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/omteam/omt/report/controller/WeeklyReportController.java
+++ b/src/main/java/com/omteam/omt/report/controller/WeeklyReportController.java
@@ -34,11 +34,15 @@ public class WeeklyReportController {
     @GetMapping("/weekly")
     public ApiResponse<WeeklyReportResponse> getWeeklyReport(
             @AuthenticationPrincipal UserPrincipal principal,
-            @Parameter(description = "주간 시작일 (미입력시 이번 주)", example = "2024-01-15")
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStartDate
+            @Parameter(description = "연도 (미입력시 이번 주)", example = "2024")
+            @RequestParam(required = false) Integer year,
+            @Parameter(description = "월 (1-12)", example = "1")
+            @RequestParam(required = false) Integer month,
+            @Parameter(description = "해당 월의 주차 (1부터 시작)", example = "3")
+            @RequestParam(required = false) Integer weekOfMonth
     ) {
         WeeklyReportResponse response = weeklyReportService.getWeeklyReport(
-                principal.userId(), weekStartDate);
+                principal.userId(), year, month, weekOfMonth);
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/com/omteam/omt/report/service/WeeklyReportService.java
+++ b/src/main/java/com/omteam/omt/report/service/WeeklyReportService.java
@@ -1,5 +1,7 @@
 package com.omteam.omt.report.service;
 
+import com.omteam.omt.common.exception.BusinessException;
+import com.omteam.omt.common.exception.ErrorCode;
 import com.omteam.omt.mission.domain.DailyMissionResult;
 import com.omteam.omt.mission.domain.MissionResult;
 import com.omteam.omt.mission.domain.MissionType;
@@ -33,8 +35,8 @@ public class WeeklyReportService {
     private final DailyMissionResultRepository missionResultRepository;
     private final WeeklyAiAnalysisRepository weeklyAiAnalysisRepository;
 
-    public WeeklyReportResponse getWeeklyReport(Long userId, LocalDate weekStartDate) {
-        LocalDate effectiveStart = resolveWeekStartDate(weekStartDate);
+    public WeeklyReportResponse getWeeklyReport(Long userId, Integer year, Integer month, Integer weekOfMonth) {
+        LocalDate effectiveStart = resolveWeekStartDate(year, month, weekOfMonth);
         LocalDate weekEnd = effectiveStart.plusDays(6);
         LocalDate today = LocalDate.now();
 
@@ -75,11 +77,31 @@ public class WeeklyReportService {
                 .build();
     }
 
-    private LocalDate resolveWeekStartDate(LocalDate weekStartDate) {
-        if (weekStartDate == null) {
+    private LocalDate resolveWeekStartDate(Integer year, Integer month, Integer weekOfMonth) {
+        if (year == null || month == null || weekOfMonth == null) {
             return LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
         }
-        return weekStartDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        if (weekOfMonth < 1) {
+            throw new BusinessException(ErrorCode.INVALID_WEEK_OF_MONTH);
+        }
+
+        // 해당 월의 첫 번째 월요일 계산
+        LocalDate firstDayOfMonth = LocalDate.of(year, month, 1);
+        LocalDate firstMonday = firstDayOfMonth.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY));
+
+        // 해당 월의 마지막 날
+        LocalDate lastDayOfMonth = firstDayOfMonth.with(TemporalAdjusters.lastDayOfMonth());
+
+        // 요청한 주차의 월요일 계산
+        LocalDate targetMonday = firstMonday.plusDays((long) (weekOfMonth - 1) * 7);
+
+        // 해당 월요일이 해당 월을 벗어나면 예외
+        if (targetMonday.isAfter(lastDayOfMonth)) {
+            throw new BusinessException(ErrorCode.INVALID_WEEK_OF_MONTH);
+        }
+
+        return targetMonday;
     }
 
     private double calculateSuccessRate(List<DailyMissionResult> results,

--- a/src/test/java/com/omteam/omt/report/service/WeeklyReportServiceTest.java
+++ b/src/test/java/com/omteam/omt/report/service/WeeklyReportServiceTest.java
@@ -3,6 +3,8 @@ package com.omteam.omt.report.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import com.omteam.omt.common.exception.BusinessException;
+import com.omteam.omt.common.exception.ErrorCode;
 import com.omteam.omt.mission.domain.DailyMissionResult;
 import com.omteam.omt.mission.domain.Mission;
 import com.omteam.omt.mission.domain.MissionResult;
@@ -38,6 +40,10 @@ class WeeklyReportServiceTest {
 
     final Long userId = 1L;
     final LocalDate monday = LocalDate.of(2024, 1, 15); // Monday
+    // 2024년 1월 15일은 1월의 3번째 월요일 (첫 번째 월요일: 1/1)
+    final Integer year = 2024;
+    final Integer month = 1;
+    final Integer weekOfMonth = 3;
 
     @BeforeEach
     void setUp() {
@@ -75,7 +81,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.thisWeekSuccessRate()).isEqualTo(71.4); // 5/7 = 71.4%
@@ -106,7 +112,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.lastWeekSuccessRate()).isEqualTo(57.1); // 4/7 = 57.1%
@@ -123,7 +129,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.thisWeekSuccessRate()).isEqualTo(0.0);
@@ -154,7 +160,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.dailyResults()).isNotEmpty();
@@ -190,7 +196,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.typeSuccessCounts()).hasSize(2);
@@ -216,7 +222,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.typeSuccessCounts()).hasSize(MissionType.values().length);
@@ -247,7 +253,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.typeSuccessCounts()).hasSize(MissionType.values().length);
@@ -280,7 +286,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.typeSuccessCounts())
@@ -322,7 +328,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.topFailureReasons()).hasSize(3);
@@ -355,7 +361,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.of(analysis));
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.aiFeedback().mainFailureReason()).isEqualTo("시간 부족");
@@ -373,7 +379,7 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, monday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, year, month, weekOfMonth);
 
             // then
             assertThat(response.aiFeedback().mainFailureReason()).isNull();
@@ -396,18 +402,18 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, null);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, null, null, null);
 
             // then
             assertThat(response.weekStartDate().getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
         }
 
         @Test
-        @DisplayName("weekStartDate가 월요일이 아닐 때 해당 주 월요일로 조정")
-        void resolveWeekStartDateWhenNotMonday() {
+        @DisplayName("year, month, weekOfMonth로 해당 월의 특정 주 월요일 계산")
+        void resolveWeekStartDateWithYearMonthWeek() {
             // given
-            LocalDate wednesday = LocalDate.of(2024, 1, 17); // Wednesday
-
+            // 2024년 2월 1일은 목요일, 첫 번째 월요일은 2024-02-05
+            // 2주차 월요일은 2024-02-12
             given(missionResultRepository.findByUserUserIdAndMissionDateBetween(
                     anyLong(), any(), any()))
                     .willReturn(List.of());
@@ -415,11 +421,43 @@ class WeeklyReportServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, wednesday);
+            WeeklyReportResponse response = weeklyReportService.getWeeklyReport(userId, 2024, 2, 2);
 
             // then
-            assertThat(response.weekStartDate()).isEqualTo(monday);
-            assertThat(response.weekEndDate()).isEqualTo(monday.plusDays(6));
+            assertThat(response.weekStartDate()).isEqualTo(LocalDate.of(2024, 2, 12));
+            assertThat(response.weekEndDate()).isEqualTo(LocalDate.of(2024, 2, 18));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 주차 요청 시 예외 발생")
+        void throwExceptionWhenInvalidWeekOfMonth() {
+            // given & when & then
+            // 2024년 2월은 최대 4주차까지 존재 (첫 번째 월요일: 2/5, 4주차 월요일: 2/26)
+            assertThatThrownBy(() -> weeklyReportService.getWeeklyReport(userId, 2024, 2, 15))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> {
+                        BusinessException be = (BusinessException) ex;
+                        assertThat(be.getErrorCode()).isEqualTo(ErrorCode.INVALID_WEEK_OF_MONTH);
+                    });
+        }
+
+        @Test
+        @DisplayName("0 이하의 주차 요청 시 예외 발생")
+        void throwExceptionWhenWeekOfMonthIsZeroOrNegative() {
+            // given & when & then
+            assertThatThrownBy(() -> weeklyReportService.getWeeklyReport(userId, 2024, 2, 0))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> {
+                        BusinessException be = (BusinessException) ex;
+                        assertThat(be.getErrorCode()).isEqualTo(ErrorCode.INVALID_WEEK_OF_MONTH);
+                    });
+
+            assertThatThrownBy(() -> weeklyReportService.getWeeklyReport(userId, 2024, 2, -1))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> {
+                        BusinessException be = (BusinessException) ex;
+                        assertThat(be.getErrorCode()).isEqualTo(ErrorCode.INVALID_WEEK_OF_MONTH);
+                    });
         }
     }
 


### PR DESCRIPTION
## 관련 이슈
Closes #65 

## 변경 내용
- 주간 리포트 조회 시 해당 주차의 시작일을 받지 않고 년,월,주차 정보를 파라미터로 받아서 해당 주차에 대한 리포트를 제공한다.


## 작업 상세
- `/api/reports/weekly` API 파라미터 형식 수정
- 존재하지 않는 주차에 대한 예외 처리 추가 (ex: 2월 10주차 -> 예외 발생)
- Swagger description 수정
- 파라미터 resolve 메서드 추가 및 service 로직에 적용 (년,월,주차 -> 시작일)
- 테스트 코드 수정

## 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 관련 이슈 해결 확인
