### PR TITLE
[FEAT] 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/omteam/omt/common/exception/ErrorCode.java
+++ b/src/main/java/com/omteam/omt/common/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     ONBOARDING_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "U003", "온보딩을 완료해주세요"),
     ONBOARDING_ALREADY_COMPLETED(HttpStatus.CONFLICT, "U004", "이미 온보딩이 완료되었습니다"),
     ONBOARDING_NOT_FOUND(HttpStatus.NOT_FOUND, "U005", "온보딩 정보를 찾을 수 없습니다"),
+    USER_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "U006", "이미 탈퇴한 사용자입니다"),
 
     // Mission (M)
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "미션을 찾을 수 없습니다"),

--- a/src/main/java/com/omteam/omt/security/auth/controller/AuthController.java
+++ b/src/main/java/com/omteam/omt/security/auth/controller/AuthController.java
@@ -74,4 +74,15 @@ public class AuthController {
                 authService.refreshToken(request.getRefreshToken())
         );
     }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "회원 탈퇴를 처리합니다. Soft Delete 방식으로 동작하며, 탈퇴 후 동일 소셜 계정으로 재가입 가능합니다."
+    )
+    @PostMapping("/withdraw")
+    public ApiResponse<Void> withdraw(@AuthenticationPrincipal UserPrincipal principal) {
+        log.info("Withdraw request: userId={}", principal.userId());
+        authService.withdraw(principal.userId());
+        return ApiResponse.success(null);
+    }
 }

--- a/src/main/java/com/omteam/omt/security/auth/service/AuthService.java
+++ b/src/main/java/com/omteam/omt/security/auth/service/AuthService.java
@@ -58,7 +58,24 @@ public class AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+        if (!user.isActive()) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_WITHDRAWN);
+        }
+
         return createLoginResponse(user);
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.isActive()) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_WITHDRAWN);
+        }
+
+        user.withdraw();
+        refreshTokenService.deleteRefreshToken(userId);
     }
 
     private OAuthClient findOAuthClient(SocialProvider provider) {

--- a/src/main/java/com/omteam/omt/user/service/UserProvisioningService.java
+++ b/src/main/java/com/omteam/omt/user/service/UserProvisioningService.java
@@ -33,6 +33,7 @@ public class UserProvisioningService {
         return socialAccountRepository
                 .findByProviderAndProviderUserId(provider, providerUserId)
                 .map(UserSocialAccount::getUser)
+                .filter(User::isActive)
                 .orElseGet(() -> createNewUser(provider, providerUserId, email));
     }
 

--- a/src/test/java/com/omteam/omt/security/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/omteam/omt/security/auth/service/AuthServiceTest.java
@@ -196,6 +196,73 @@ class AuthServiceTest {
                 .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
     }
 
+    @Test
+    @DisplayName("토큰 갱신 실패 - 탈퇴한 사용자")
+    void refreshToken_fail_withdrawn_user() {
+        // given
+        String refreshToken = "valid-refresh-token";
+        Long userId = 1L;
+        User withdrawnUser = spy(createUser(true));
+        given(withdrawnUser.isActive()).willReturn(false);
+
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getUserId(refreshToken)).willReturn(userId);
+        given(refreshTokenService.validateRefreshToken(userId, refreshToken)).willReturn(true);
+        given(userRepository.findById(userId)).willReturn(Optional.of(withdrawnUser));
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(refreshToken))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_ALREADY_WITHDRAWN);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공")
+    void withdraw_success() {
+        // given
+        Long userId = 1L;
+        User user = createUser(true);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        authService.withdraw(userId);
+
+        // then
+        then(userRepository).should().findById(userId);
+        then(refreshTokenService).should().deleteRefreshToken(userId);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 실패 - 사용자 없음")
+    void withdraw_fail_user_not_found() {
+        // given
+        Long userId = 1L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.withdraw(userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 실패 - 이미 탈퇴한 사용자")
+    void withdraw_fail_already_withdrawn() {
+        // given
+        Long userId = 1L;
+        User withdrawnUser = spy(createUser(true));
+        given(withdrawnUser.isActive()).willReturn(false);
+        given(userRepository.findById(userId)).willReturn(Optional.of(withdrawnUser));
+
+        // when & then
+        assertThatThrownBy(() -> authService.withdraw(userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_ALREADY_WITHDRAWN);
+    }
+
     /* ======================== */
     /* ===== Helper Zone ====== */
     /* ======================== */

--- a/src/test/java/com/omteam/omt/user/service/UserProvisioningServiceTest.java
+++ b/src/test/java/com/omteam/omt/user/service/UserProvisioningServiceTest.java
@@ -126,6 +126,33 @@ class UserProvisioningServiceTest {
         assertThat(savedCharacter.getSuccessCount()).isEqualTo(0);
     }
 
+    @Test
+    @DisplayName("재가입 - 탈퇴한 사용자의 소셜 계정으로 로그인 시 새 계정 생성")
+    void findOrCreateUser_creates_new_user_when_existing_is_withdrawn() {
+        // given
+        User withdrawnUser = spy(createUser());
+        given(withdrawnUser.isActive()).willReturn(false);
+        UserSocialAccount socialAccount = UserSocialAccount.builder()
+                .user(withdrawnUser)
+                .provider(provider)
+                .providerUserId(providerUserId)
+                .build();
+
+        User newUser = createUser();
+        given(socialAccountRepository.findByProviderAndProviderUserId(provider, providerUserId))
+                .willReturn(Optional.of(socialAccount));
+        given(userRepository.save(any(User.class))).willReturn(newUser);
+
+        // when
+        User result = userProvisioningService.findOrCreateUser(provider, providerUserId, email);
+
+        // then
+        assertThat(result).isEqualTo(newUser);
+        then(userRepository).should().save(any(User.class));
+        then(socialAccountRepository).should().save(any(UserSocialAccount.class));
+        then(characterRepository).should().save(any(UserCharacter.class));
+    }
+
     private User createUser() {
         return User.builder()
                 .userId(1L)


### PR DESCRIPTION
## 관련 이슈
Closes #67 

## 변경 내용
- POST /auth/withdraw 엔드포인트 추가
- Soft Delete 방식으로 User.deletedAt 설정
- 탈퇴 후 동일 소셜 계정으로 재가입 허용
- 탈퇴한 사용자의 토큰 갱신 차단

## 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 관련 이슈 해결 확인