### PR TITLE
[FEAT] 온보딩 기상/취침 시간 및 FCM 토큰 데이터 모델 추가

### DIFF
--- a/src/main/java/com/omteam/omt/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/omteam/omt/onboarding/controller/OnboardingController.java
@@ -11,6 +11,7 @@ import com.omteam.omt.onboarding.dto.request.UpdateNicknameRequest;
 import com.omteam.omt.onboarding.dto.request.UpdateNotificationSettingRequest;
 import com.omteam.omt.onboarding.dto.request.UpdatePreferredExerciseRequest;
 import com.omteam.omt.onboarding.dto.request.UpdateSingleNotificationRequest;
+import com.omteam.omt.onboarding.dto.request.UpdateSleepScheduleRequest;
 import com.omteam.omt.onboarding.dto.request.UpdateWorkTimeRequest;
 import com.omteam.omt.onboarding.service.OnboardingService;
 import com.omteam.omt.security.principal.UserPrincipal;
@@ -195,6 +196,24 @@ public class OnboardingController {
                         request.getRemindEnabled(),
                         request.getCheckinEnabled(),
                         request.getReviewEnabled()
+                )
+        );
+    }
+
+    @Operation(
+            summary = "기상/취침 시간 수정",
+            description = "사용자의 기상 시간과 취침 시간을 수정합니다. (30분 단위, 선택)"
+    )
+    @PatchMapping("/sleep-schedule")
+    public ApiResponse<OnboardingResponse> updateSleepSchedule(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody UpdateSleepScheduleRequest request
+    ) {
+        return ApiResponse.success(
+                onboardingService.updateSleepSchedule(
+                        userPrincipal.userId(),
+                        request.getWakeUpTime(),
+                        request.getBedTime()
                 )
         );
     }

--- a/src/main/java/com/omteam/omt/onboarding/dto/OnboardingRequest.java
+++ b/src/main/java/com/omteam/omt/onboarding/dto/OnboardingRequest.java
@@ -1,9 +1,11 @@
 package com.omteam.omt.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.omteam.omt.user.domain.LifestyleType;
 import com.omteam.omt.user.domain.WorkTimeType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -100,4 +102,22 @@ public class OnboardingRequest {
     )
     @NotNull(message = "리뷰 알림 설정은 필수입니다")
     private Boolean reviewEnabled;
+
+    @Schema(description = "기상 시간 (HH:mm, 30분 단위, 선택)", example = "07:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime wakeUpTime;
+
+    @Schema(description = "취침 시간 (HH:mm, 30분 단위, 선택)", example = "23:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime bedTime;
+
+    @AssertTrue(message = "기상 시간은 30분 단위여야 합니다 (예: 07:00, 07:30)")
+    public boolean isWakeUpTimeValid() {
+        return wakeUpTime == null || wakeUpTime.getMinute() % 30 == 0;
+    }
+
+    @AssertTrue(message = "취침 시간은 30분 단위여야 합니다 (예: 23:00, 23:30)")
+    public boolean isBedTimeValid() {
+        return bedTime == null || bedTime.getMinute() % 30 == 0;
+    }
 }

--- a/src/main/java/com/omteam/omt/onboarding/dto/OnboardingResponse.java
+++ b/src/main/java/com/omteam/omt/onboarding/dto/OnboardingResponse.java
@@ -25,6 +25,8 @@ public class OnboardingResponse {
     private boolean remindEnabled;
     private boolean checkinEnabled;
     private boolean reviewEnabled;
+    private LocalTime wakeUpTime;
+    private LocalTime bedTime;
 
     public static OnboardingResponse of(
             User user,
@@ -43,6 +45,8 @@ public class OnboardingResponse {
                 .remindEnabled(notificationSetting.isRemindEnabled())
                 .checkinEnabled(notificationSetting.isCheckinEnabled())
                 .reviewEnabled(notificationSetting.isReviewEnabled())
+                .wakeUpTime(onboarding.getWakeUpTime())
+                .bedTime(onboarding.getBedTime())
                 .build();
     }
 }

--- a/src/main/java/com/omteam/omt/onboarding/dto/request/UpdateSleepScheduleRequest.java
+++ b/src/main/java/com/omteam/omt/onboarding/dto/request/UpdateSleepScheduleRequest.java
@@ -1,0 +1,34 @@
+package com.omteam.omt.onboarding.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "기상/취침 시간 수정 요청")
+public class UpdateSleepScheduleRequest {
+
+    @Schema(description = "기상 시간 (HH:mm, 30분 단위, 선택)", example = "07:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime wakeUpTime;
+
+    @Schema(description = "취침 시간 (HH:mm, 30분 단위, 선택)", example = "23:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime bedTime;
+
+    @AssertTrue(message = "기상 시간은 30분 단위여야 합니다 (예: 07:00, 07:30)")
+    public boolean isWakeUpTimeValid() {
+        return wakeUpTime == null || wakeUpTime.getMinute() % 30 == 0;
+    }
+
+    @AssertTrue(message = "취침 시간은 30분 단위여야 합니다 (예: 23:00, 23:30)")
+    public boolean isBedTimeValid() {
+        return bedTime == null || bedTime.getMinute() % 30 == 0;
+    }
+}

--- a/src/main/java/com/omteam/omt/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/omteam/omt/onboarding/service/OnboardingService.java
@@ -46,6 +46,8 @@ public class OnboardingService {
                 .minExerciseMinutes(request.getMinExerciseMinutes())
                 .preferredExercises(request.getPreferredExercises())
                 .lifestyleType(request.getLifestyleType())
+                .wakeUpTime(request.getWakeUpTime())
+                .bedTime(request.getBedTime())
                 .build();
 
         UserNotificationSetting notificationSetting = UserNotificationSetting.builder()
@@ -85,6 +87,7 @@ public class OnboardingService {
                 request.getPreferredExercises(),
                 request.getLifestyleType()
         );
+        onboarding.updateSleepSchedule(request.getWakeUpTime(), request.getBedTime());
 
         notificationSetting.update(
                 request.getRemindEnabled(),
@@ -164,6 +167,13 @@ public class OnboardingService {
     public OnboardingResponse updateNotificationSetting(Long userId, boolean remindEnabled, boolean checkinEnabled, boolean reviewEnabled) {
         OnboardingContext ctx = fetchOnboardingContext(userId);
         ctx.notificationSetting.update(remindEnabled, checkinEnabled, reviewEnabled);
+        return OnboardingResponse.of(ctx.user, ctx.onboarding, ctx.notificationSetting);
+    }
+
+    @Transactional
+    public OnboardingResponse updateSleepSchedule(Long userId, LocalTime wakeUpTime, LocalTime bedTime) {
+        OnboardingContext ctx = fetchOnboardingContext(userId);
+        ctx.onboarding.updateSleepSchedule(wakeUpTime, bedTime);
         return OnboardingResponse.of(ctx.user, ctx.onboarding, ctx.notificationSetting);
     }
 

--- a/src/main/java/com/omteam/omt/user/domain/User.java
+++ b/src/main/java/com/omteam/omt/user/domain/User.java
@@ -39,6 +39,9 @@ public class User {
     @Column(nullable = false)
     private boolean onboardingCompleted;
 
+    @Column(length = 512)
+    private String fcmToken;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -58,6 +61,10 @@ public class User {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 
     public boolean isActive() {

--- a/src/main/java/com/omteam/omt/user/domain/UserOnboarding.java
+++ b/src/main/java/com/omteam/omt/user/domain/UserOnboarding.java
@@ -64,6 +64,10 @@ public class UserOnboarding {
     @Column(nullable = false)
     private LifestyleType lifestyleType;
 
+    private LocalTime wakeUpTime;
+
+    private LocalTime bedTime;
+
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
@@ -108,5 +112,10 @@ public class UserOnboarding {
 
     public void updateLifestyleType(LifestyleType lifestyleType) {
         this.lifestyleType = lifestyleType;
+    }
+
+    public void updateSleepSchedule(LocalTime wakeUpTime, LocalTime bedTime) {
+        this.wakeUpTime = wakeUpTime;
+        this.bedTime = bedTime;
     }
 }

--- a/src/main/java/com/omteam/omt/user/repository/UserOnboardingRepository.java
+++ b/src/main/java/com/omteam/omt/user/repository/UserOnboardingRepository.java
@@ -1,10 +1,26 @@
 package com.omteam.omt.user.repository;
 
 import com.omteam.omt.user.domain.UserOnboarding;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserOnboardingRepository extends JpaRepository<UserOnboarding, Long> {
 
     Optional<UserOnboarding> findByUserId(Long userId);
+
+    // 리마인드: availableStartTime == time
+    @Query("SELECT uo FROM UserOnboarding uo JOIN FETCH uo.user u WHERE uo.availableStartTime = :time AND u.onboardingCompleted = true AND u.deletedAt IS NULL")
+    List<UserOnboarding> findByAvailableStartTimeForNotification(@Param("time") LocalTime time);
+
+    // 체크인: wakeUpTime == time, null이면 defaultTime과 비교
+    @Query("SELECT uo FROM UserOnboarding uo JOIN FETCH uo.user u WHERE (uo.wakeUpTime = :time OR (uo.wakeUpTime IS NULL AND :time = :defaultTime)) AND u.onboardingCompleted = true AND u.deletedAt IS NULL")
+    List<UserOnboarding> findByEffectiveWakeUpTime(@Param("time") LocalTime time, @Param("defaultTime") LocalTime defaultTime);
+
+    // 회고: bedTime == targetBedTime (now + 1h), null이면 defaultReviewTime과 비교
+    @Query("SELECT uo FROM UserOnboarding uo JOIN FETCH uo.user u WHERE (uo.bedTime = :targetBedTime OR (uo.bedTime IS NULL AND :now = :defaultReviewTime)) AND u.onboardingCompleted = true AND u.deletedAt IS NULL")
+    List<UserOnboarding> findByBedTimeForReview(@Param("targetBedTime") LocalTime targetBedTime, @Param("now") LocalTime now, @Param("defaultReviewTime") LocalTime defaultReviewTime);
 }

--- a/src/test/java/com/omteam/omt/onboarding/controller/OnboardingControllerTest.java
+++ b/src/test/java/com/omteam/omt/onboarding/controller/OnboardingControllerTest.java
@@ -14,6 +14,7 @@ import com.omteam.omt.onboarding.dto.request.UpdateNicknameRequest;
 import com.omteam.omt.onboarding.dto.request.UpdateNotificationSettingRequest;
 import com.omteam.omt.onboarding.dto.request.UpdatePreferredExerciseRequest;
 import com.omteam.omt.onboarding.dto.request.UpdateSingleNotificationRequest;
+import com.omteam.omt.onboarding.dto.request.UpdateSleepScheduleRequest;
 import com.omteam.omt.onboarding.dto.request.UpdateWorkTimeRequest;
 import com.omteam.omt.onboarding.service.OnboardingService;
 import com.omteam.omt.security.principal.UserPrincipal;
@@ -468,6 +469,70 @@ class OnboardingControllerTest {
             assertThat(result.success()).isTrue();
 
             then(onboardingService).should().updateSingleNotification(principal.userId(), NotificationType.REVIEW, true);
+        }
+    }
+
+        @Nested
+    @DisplayName("기상/취침 시간 수정")
+    class UpdateSleepSchedule {
+
+        @Test
+        @DisplayName("성공 - 기상/취침 시간이 수정된다")
+        void success_withBothTimes() {
+            // given
+            LocalTime wakeUpTime = LocalTime.of(7, 0);
+            LocalTime bedTime = LocalTime.of(23, 0);
+
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setWakeUpTime(wakeUpTime);
+            request.setBedTime(bedTime);
+
+            OnboardingResponse response = OnboardingResponse.builder()
+                    .nickname("테스트유저")
+                    .wakeUpTime(wakeUpTime)
+                    .bedTime(bedTime)
+                    .build();
+
+            given(onboardingService.updateSleepSchedule(principal.userId(), wakeUpTime, bedTime))
+                    .willReturn(response);
+
+            // when
+            ApiResponse<OnboardingResponse> result =
+                    onboardingController.updateSleepSchedule(principal, request);
+
+            // then
+            assertThat(result.success()).isTrue();
+            assertThat(result.data().getWakeUpTime()).isEqualTo(wakeUpTime);
+            assertThat(result.data().getBedTime()).isEqualTo(bedTime);
+
+            then(onboardingService).should().updateSleepSchedule(principal.userId(), wakeUpTime, bedTime);
+        }
+
+        @Test
+        @DisplayName("성공 - null 값으로 기상/취침 시간을 초기화한다")
+        void success_withNullTimes() {
+            // given
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+
+            OnboardingResponse response = OnboardingResponse.builder()
+                    .nickname("테스트유저")
+                    .wakeUpTime(null)
+                    .bedTime(null)
+                    .build();
+
+            given(onboardingService.updateSleepSchedule(principal.userId(), null, null))
+                    .willReturn(response);
+
+            // when
+            ApiResponse<OnboardingResponse> result =
+                    onboardingController.updateSleepSchedule(principal, request);
+
+            // then
+            assertThat(result.success()).isTrue();
+            assertThat(result.data().getWakeUpTime()).isNull();
+            assertThat(result.data().getBedTime()).isNull();
+
+            then(onboardingService).should().updateSleepSchedule(principal.userId(), null, null);
         }
     }
 

--- a/src/test/java/com/omteam/omt/onboarding/dto/request/UpdateSleepScheduleRequestTest.java
+++ b/src/test/java/com/omteam/omt/onboarding/dto/request/UpdateSleepScheduleRequestTest.java
@@ -1,0 +1,190 @@
+package com.omteam.omt.onboarding.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalTime;
+import java.util.Set;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[단위] UpdateSleepScheduleRequest 유효성 검증")
+class UpdateSleepScheduleRequestTest {
+
+    static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Nested
+    @DisplayName("wakeUpTime 검증")
+    class WakeUpTimeValidation {
+
+        @Test
+        @DisplayName("null이면 유효하다")
+        void valid_null() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setWakeUpTime(null);
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("분이 0이면 유효하다")
+        void valid_minuteZero() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setWakeUpTime(LocalTime.of(7, 0));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("분이 30이면 유효하다")
+        void valid_minuteThirty() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setWakeUpTime(LocalTime.of(7, 30));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("분이 15이면 유효하지 않다")
+        void invalid_minuteFifteen() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setWakeUpTime(LocalTime.of(7, 15));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).hasSize(1);
+            assertThat(violations.iterator().next().getMessage())
+                    .isEqualTo("기상 시간은 30분 단위여야 합니다 (예: 07:00, 07:30)");
+        }
+
+        @Test
+        @DisplayName("분이 45이면 유효하지 않다")
+        void invalid_minuteFortyFive() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setWakeUpTime(LocalTime.of(7, 45));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("bedTime 검증")
+    class BedTimeValidation {
+
+        @Test
+        @DisplayName("null이면 유효하다")
+        void valid_null() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setBedTime(null);
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("분이 0이면 유효하다")
+        void valid_minuteZero() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setBedTime(LocalTime.of(23, 0));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("분이 30이면 유효하다")
+        void valid_minuteThirty() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setBedTime(LocalTime.of(23, 30));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("분이 10이면 유효하지 않다")
+        void invalid_minuteTen() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setBedTime(LocalTime.of(23, 10));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).hasSize(1);
+            assertThat(violations.iterator().next().getMessage())
+                    .isEqualTo("취침 시간은 30분 단위여야 합니다 (예: 23:00, 23:30)");
+        }
+    }
+
+    @Nested
+    @DisplayName("기상/취침 시간 동시 설정")
+    class BothTimesValidation {
+
+        @Test
+        @DisplayName("두 시간 모두 유효한 30분 단위이면 유효하다")
+        void valid_bothValid() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setWakeUpTime(LocalTime.of(6, 30));
+            request.setBedTime(LocalTime.of(22, 30));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("두 시간 모두 null이면 유효하다")
+        void valid_bothNull() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("wakeUpTime이 유효하지 않으면 violations가 1개 발생한다")
+        void invalid_wakeUpTimeOnly() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setWakeUpTime(LocalTime.of(7, 20));
+            request.setBedTime(LocalTime.of(23, 0));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("두 시간 모두 유효하지 않으면 violations가 2개 발생한다")
+        void invalid_both() {
+            UpdateSleepScheduleRequest request = new UpdateSleepScheduleRequest();
+            request.setWakeUpTime(LocalTime.of(7, 15));
+            request.setBedTime(LocalTime.of(23, 15));
+
+            Set<ConstraintViolation<UpdateSleepScheduleRequest>> violations = validator.validate(request);
+
+            assertThat(violations).hasSize(2);
+        }
+    }
+}

--- a/src/test/java/com/omteam/omt/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/omteam/omt/onboarding/service/OnboardingServiceTest.java
@@ -1,0 +1,331 @@
+package com.omteam.omt.onboarding.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.omteam.omt.common.exception.BusinessException;
+import com.omteam.omt.common.exception.ErrorCode;
+import com.omteam.omt.onboarding.dto.OnboardingRequest;
+import com.omteam.omt.onboarding.dto.OnboardingResponse;
+import com.omteam.omt.user.domain.LifestyleType;
+import com.omteam.omt.user.domain.User;
+import com.omteam.omt.user.domain.UserNotificationSetting;
+import com.omteam.omt.user.domain.UserOnboarding;
+import com.omteam.omt.user.domain.WorkTimeType;
+import com.omteam.omt.user.repository.UserNotificationSettingRepository;
+import com.omteam.omt.user.repository.UserOnboardingRepository;
+import com.omteam.omt.user.service.UserQueryService;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[단위] OnboardingService")
+class OnboardingServiceTest {
+
+    @Mock
+    UserQueryService userQueryService;
+
+    @Mock
+    UserOnboardingRepository userOnboardingRepository;
+
+    @Mock
+    UserNotificationSettingRepository userNotificationSettingRepository;
+
+    @InjectMocks
+    OnboardingService onboardingService;
+
+    final Long userId = 1L;
+
+    @Nested
+    @DisplayName("온보딩 등록 (createOnboarding)")
+    class CreateOnboarding {
+
+        @Test
+        @DisplayName("성공 - wakeUpTime/bedTime 포함하여 온보딩 등록")
+        void success_withSleepSchedule() {
+            // given
+            User user = createIncompleteUser();
+            given(userQueryService.getUser(userId)).willReturn(user);
+
+            OnboardingRequest request = createOnboardingRequest(
+                    LocalTime.of(7, 0), LocalTime.of(23, 30)
+            );
+
+            // when
+            OnboardingResponse response = onboardingService.createOnboarding(userId, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getNickname()).isEqualTo("테스트유저");
+            assertThat(response.getWakeUpTime()).isEqualTo(LocalTime.of(7, 0));
+            assertThat(response.getBedTime()).isEqualTo(LocalTime.of(23, 30));
+
+            then(userOnboardingRepository).should().save(any(UserOnboarding.class));
+            then(userNotificationSettingRepository).should().save(any(UserNotificationSetting.class));
+        }
+
+        @Test
+        @DisplayName("성공 - wakeUpTime/bedTime null로 온보딩 등록")
+        void success_withoutSleepSchedule() {
+            // given
+            User user = createIncompleteUser();
+            given(userQueryService.getUser(userId)).willReturn(user);
+
+            OnboardingRequest request = createOnboardingRequest(null, null);
+
+            // when
+            OnboardingResponse response = onboardingService.createOnboarding(userId, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getWakeUpTime()).isNull();
+            assertThat(response.getBedTime()).isNull();
+
+            then(userOnboardingRepository).should().save(any(UserOnboarding.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 온보딩이 이미 완료된 경우 ONBOARDING_ALREADY_COMPLETED 예외")
+        void fail_onboardingAlreadyCompleted() {
+            // given
+            User user = createCompletedUser();
+            given(userQueryService.getUser(userId)).willReturn(user);
+
+            OnboardingRequest request = createOnboardingRequest(LocalTime.of(7, 0), LocalTime.of(23, 0));
+
+            // when & then
+            assertThatThrownBy(() -> onboardingService.createOnboarding(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.ONBOARDING_ALREADY_COMPLETED);
+
+            then(userOnboardingRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("온보딩 수정 (updateOnboarding)")
+    class UpdateOnboarding {
+
+        @Test
+        @DisplayName("성공 - wakeUpTime/bedTime 포함하여 온보딩 수정")
+        void success_withSleepSchedule() {
+            // given
+            User user = createCompletedUser();
+            UserOnboarding onboarding = createUserOnboarding(user);
+            UserNotificationSetting notificationSetting = createNotificationSetting(user);
+
+            given(userQueryService.getUser(userId)).willReturn(user);
+            given(userQueryService.getUserOnboarding(userId)).willReturn(onboarding);
+            given(userNotificationSettingRepository.findByUserId(userId)).willReturn(Optional.of(notificationSetting));
+
+            OnboardingRequest request = createOnboardingRequest(
+                    LocalTime.of(6, 30), LocalTime.of(22, 0)
+            );
+
+            // when
+            OnboardingResponse response = onboardingService.updateOnboarding(userId, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getWakeUpTime()).isEqualTo(LocalTime.of(6, 30));
+            assertThat(response.getBedTime()).isEqualTo(LocalTime.of(22, 0));
+        }
+
+        @Test
+        @DisplayName("성공 - wakeUpTime/bedTime null로 수정 (기존 값 초기화)")
+        void success_clearingSleepSchedule() {
+            // given
+            User user = createCompletedUser();
+            UserOnboarding onboarding = createUserOnboardingWithSleepSchedule(
+                    user, LocalTime.of(7, 0), LocalTime.of(23, 0)
+            );
+            UserNotificationSetting notificationSetting = createNotificationSetting(user);
+
+            given(userQueryService.getUser(userId)).willReturn(user);
+            given(userQueryService.getUserOnboarding(userId)).willReturn(onboarding);
+            given(userNotificationSettingRepository.findByUserId(userId)).willReturn(Optional.of(notificationSetting));
+
+            OnboardingRequest request = createOnboardingRequest(null, null);
+
+            // when
+            OnboardingResponse response = onboardingService.updateOnboarding(userId, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getWakeUpTime()).isNull();
+            assertThat(response.getBedTime()).isNull();
+        }
+
+        @Test
+        @DisplayName("실패 - 온보딩 미완료 상태에서 수정 시 ONBOARDING_NOT_COMPLETED 예외")
+        void fail_onboardingNotCompleted() {
+            // given
+            User user = createIncompleteUser();
+            given(userQueryService.getUser(userId)).willReturn(user);
+
+            OnboardingRequest request = createOnboardingRequest(LocalTime.of(7, 0), LocalTime.of(23, 0));
+
+            // when & then
+            assertThatThrownBy(() -> onboardingService.updateOnboarding(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.ONBOARDING_NOT_COMPLETED);
+        }
+    }
+
+    @Nested
+    @DisplayName("기상/취침 시간 수정 (updateSleepSchedule)")
+    class UpdateSleepSchedule {
+
+        @Test
+        @DisplayName("성공 - 기상/취침 시간이 수정된다")
+        void success_withBothTimes() {
+            // given
+            User user = createCompletedUser();
+            UserOnboarding onboarding = createUserOnboarding(user);
+            UserNotificationSetting notificationSetting = createNotificationSetting(user);
+
+            given(userQueryService.getUser(userId)).willReturn(user);
+            given(userQueryService.getUserOnboarding(userId)).willReturn(onboarding);
+            given(userNotificationSettingRepository.findByUserId(userId)).willReturn(Optional.of(notificationSetting));
+
+            LocalTime wakeUpTime = LocalTime.of(7, 30);
+            LocalTime bedTime = LocalTime.of(23, 0);
+
+            // when
+            OnboardingResponse response = onboardingService.updateSleepSchedule(userId, wakeUpTime, bedTime);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getWakeUpTime()).isEqualTo(wakeUpTime);
+            assertThat(response.getBedTime()).isEqualTo(bedTime);
+        }
+
+        @Test
+        @DisplayName("성공 - null 값으로 기상/취침 시간을 초기화한다")
+        void success_withNullTimes() {
+            // given
+            User user = createCompletedUser();
+            UserOnboarding onboarding = createUserOnboardingWithSleepSchedule(
+                    user, LocalTime.of(7, 0), LocalTime.of(23, 0)
+            );
+            UserNotificationSetting notificationSetting = createNotificationSetting(user);
+
+            given(userQueryService.getUser(userId)).willReturn(user);
+            given(userQueryService.getUserOnboarding(userId)).willReturn(onboarding);
+            given(userNotificationSettingRepository.findByUserId(userId)).willReturn(Optional.of(notificationSetting));
+
+            // when
+            OnboardingResponse response = onboardingService.updateSleepSchedule(userId, null, null);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getWakeUpTime()).isNull();
+            assertThat(response.getBedTime()).isNull();
+        }
+
+        @Test
+        @DisplayName("실패 - 온보딩 미완료 상태에서 수정 시 ONBOARDING_NOT_COMPLETED 예외")
+        void fail_onboardingNotCompleted() {
+            // given
+            User user = createIncompleteUser();
+            given(userQueryService.getUser(userId)).willReturn(user);
+
+            // when & then
+            assertThatThrownBy(() -> onboardingService.updateSleepSchedule(
+                    userId, LocalTime.of(7, 0), LocalTime.of(23, 0)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.ONBOARDING_NOT_COMPLETED);
+        }
+    }
+
+    /* ======================== */
+    /* ===== Helper Zone ====== */
+    /* ======================== */
+
+    private User createIncompleteUser() {
+        return User.builder()
+                .userId(userId)
+                .email("test@example.com")
+                .build();
+    }
+
+    private User createCompletedUser() {
+        return User.builder()
+                .userId(userId)
+                .email("test@example.com")
+                .nickname("테스트유저")
+                .onboardingCompleted(true)
+                .build();
+    }
+
+    private UserOnboarding createUserOnboarding(User user) {
+        return UserOnboarding.builder()
+                .user(user)
+                .appGoalText("체중 감량")
+                .workTimeType(WorkTimeType.FIXED)
+                .availableStartTime(LocalTime.of(18, 0))
+                .availableEndTime(LocalTime.of(21, 0))
+                .minExerciseMinutes(30)
+                .preferredExercises(List.of("스트레칭", "걷기"))
+                .lifestyleType(LifestyleType.REGULAR_DAYTIME)
+                .build();
+    }
+
+    private UserOnboarding createUserOnboardingWithSleepSchedule(
+            User user, LocalTime wakeUpTime, LocalTime bedTime) {
+        return UserOnboarding.builder()
+                .user(user)
+                .appGoalText("체중 감량")
+                .workTimeType(WorkTimeType.FIXED)
+                .availableStartTime(LocalTime.of(18, 0))
+                .availableEndTime(LocalTime.of(21, 0))
+                .minExerciseMinutes(30)
+                .preferredExercises(List.of("스트레칭", "걷기"))
+                .lifestyleType(LifestyleType.REGULAR_DAYTIME)
+                .wakeUpTime(wakeUpTime)
+                .bedTime(bedTime)
+                .build();
+    }
+
+    private UserNotificationSetting createNotificationSetting(User user) {
+        return UserNotificationSetting.builder()
+                .user(user)
+                .remindEnabled(true)
+                .checkinEnabled(true)
+                .reviewEnabled(true)
+                .build();
+    }
+
+    private OnboardingRequest createOnboardingRequest(LocalTime wakeUpTime, LocalTime bedTime) {
+        OnboardingRequest request = new OnboardingRequest();
+        request.setNickname("테스트유저");
+        request.setAppGoalText("체중 감량");
+        request.setWorkTimeType(WorkTimeType.FIXED);
+        request.setAvailableStartTime(LocalTime.of(18, 0));
+        request.setAvailableEndTime(LocalTime.of(21, 0));
+        request.setMinExerciseMinutes(30);
+        request.setPreferredExercises(List.of("스트레칭", "걷기"));
+        request.setLifestyleType(LifestyleType.REGULAR_DAYTIME);
+        request.setRemindEnabled(true);
+        request.setCheckinEnabled(true);
+        request.setReviewEnabled(true);
+        request.setWakeUpTime(wakeUpTime);
+        request.setBedTime(bedTime);
+        return request;
+    }
+}


### PR DESCRIPTION
## Summary
- `User.fcmToken` 필드 추가 (`@Column(length = 512)`) + `updateFcmToken()` 메서드
- `UserOnboarding.wakeUpTime`, `bedTime` 필드 추가 (nullable `LocalTime`) + `updateSleepSchedule()` 메서드
- `OnboardingRequest/Response`에 `wakeUpTime`, `bedTime` 추가 (`@JsonFormat`, 30분 단위 `@AssertTrue` 검증)
- `OnboardingService.createOnboarding`, `updateOnboarding`에 sleep schedule 연동
- `PATCH /api/onboarding/sleep-schedule` 엔드포인트 신규 추가
- `UserOnboardingRepository`에 스케줄러용 JPQL 쿼리 3개 추가 (리마인드/체크인/회고 알림 조회)

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `User.java` | `fcmToken` 필드 + `updateFcmToken()` |
| `UserOnboarding.java` | `wakeUpTime`, `bedTime` 필드 + `updateSleepSchedule()` |
| `OnboardingRequest.java` | `wakeUpTime`, `bedTime` + 30분 단위 검증 |
| `OnboardingResponse.java` | `wakeUpTime`, `bedTime` 응답 필드 |
| `OnboardingService.java` | `createOnboarding`, `updateOnboarding`, `updateSleepSchedule` 업데이트 |
| `OnboardingController.java` | `PATCH /api/onboarding/sleep-schedule` 추가 |
| `UpdateSleepScheduleRequest.java` | 신규 DTO (30분 단위 검증 포함) |
| `UserOnboardingRepository.java` | 알림 스케줄러용 JPQL 쿼리 3개 |

## Test plan
- [x] `OnboardingServiceTest` - createOnboarding/updateOnboarding/updateSleepSchedule 단위 테스트
- [x] `OnboardingControllerTest` - sleep-schedule 엔드포인트 단위 테스트
- [x] `UpdateSleepScheduleRequestTest` - 30분 단위 검증 테스트 (null, 0분, 30분, 15분, 45분 등 엣지케이스)
- [x] 전체 빌드 통과

Closes #108