### PR TITLE
[FEAT] Firebase Admin SDK 설치 및 FCM 발송 서비스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     // Resilience4j (Circuit Breaker)
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 
+    // Firebase Admin SDK
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
+
     // Swagger/OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
 

--- a/src/main/java/com/omteam/omt/common/exception/ErrorCode.java
+++ b/src/main/java/com/omteam/omt/common/exception/ErrorCode.java
@@ -52,7 +52,10 @@ public enum ErrorCode {
 
     // Report (R)
     DAILY_FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "해당 날짜의 피드백을 찾을 수 없습니다"),
-    INVALID_WEEK_OF_MONTH(HttpStatus.BAD_REQUEST, "R002", "해당 월에 존재하지 않는 주차입니다");
+    INVALID_WEEK_OF_MONTH(HttpStatus.BAD_REQUEST, "R002", "해당 월에 존재하지 않는 주차입니다"),
+
+    // Notification (N)
+    FCM_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "푸시 알림 전송에 실패했습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/omteam/omt/config/FcmConfig.java
+++ b/src/main/java/com/omteam/omt/config/FcmConfig.java
@@ -20,7 +20,7 @@ public class FcmConfig {
 
     @PostConstruct
     public void initFirebase() {
-        if (serviceAccountPath == null || serviceAccountPath.isBlank()) {
+        if (serviceAccountPath.isBlank()) {
             log.warn("FCM_SERVICE_ACCOUNT_PATH is not configured. FCM push notifications will be disabled.");
             return;
         }

--- a/src/main/java/com/omteam/omt/config/FcmConfig.java
+++ b/src/main/java/com/omteam/omt/config/FcmConfig.java
@@ -1,0 +1,44 @@
+package com.omteam.omt.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class FcmConfig {
+
+    @Value("${fcm.service-account-path:}")
+    private String serviceAccountPath;
+
+    @PostConstruct
+    public void initFirebase() {
+        if (serviceAccountPath == null || serviceAccountPath.isBlank()) {
+            log.warn("FCM_SERVICE_ACCOUNT_PATH is not configured. FCM push notifications will be disabled.");
+            return;
+        }
+
+        if (!FirebaseApp.getApps().isEmpty()) {
+            log.info("Firebase Admin SDK is already initialized.");
+            return;
+        }
+
+        try (InputStream is = new FileInputStream(serviceAccountPath)) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(is))
+                    .build();
+            FirebaseApp.initializeApp(options);
+            log.info("Firebase Admin SDK initialized successfully.");
+        } catch (IOException e) {
+            log.error("Failed to initialize Firebase Admin SDK: {}", e.getMessage());
+            throw new IllegalStateException("Firebase initialization failed", e);
+        }
+    }
+}

--- a/src/main/java/com/omteam/omt/notification/service/FcmService.java
+++ b/src/main/java/com/omteam/omt/notification/service/FcmService.java
@@ -1,0 +1,45 @@
+package com.omteam.omt.notification.service;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.omteam.omt.common.exception.BusinessException;
+import com.omteam.omt.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class FcmService {
+
+    public void sendNotification(String token, String title, String body) {
+        if (FirebaseApp.getApps().isEmpty()) {
+            log.debug("Firebase not initialized. Skipping FCM notification.");
+            return;
+        }
+
+        if (token == null || token.isBlank()) {
+            log.warn("FCM token is null or blank. Skipping notification.");
+            return;
+        }
+
+        Message message = Message.builder()
+                .setToken(token)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .build();
+
+        try {
+            String messageId = FirebaseMessaging.getInstance().send(message);
+            log.info("FCM notification sent successfully. messageId={}", messageId);
+        } catch (FirebaseMessagingException e) {
+            log.warn("FCM send failed [token={}]: errorCode={}, msg={}",
+                    token, e.getMessagingErrorCode(), e.getMessage());
+            throw new BusinessException(ErrorCode.FCM_SEND_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/omteam/omt/notification/service/FcmService.java
+++ b/src/main/java/com/omteam/omt/notification/service/FcmService.java
@@ -37,8 +37,7 @@ public class FcmService {
             String messageId = FirebaseMessaging.getInstance().send(message);
             log.info("FCM notification sent successfully. messageId={}", messageId);
         } catch (FirebaseMessagingException e) {
-            log.warn("FCM send failed [token={}]: errorCode={}, msg={}",
-                    token, e.getMessagingErrorCode(), e.getMessage());
+            log.warn("FCM send failed: errorCode={}, msg={}", e.getMessagingErrorCode(), e.getMessage());
             throw new BusinessException(ErrorCode.FCM_SEND_FAILED);
         }
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,3 +43,13 @@ jwt:
 ai-server:
   base-url: ${AI_SERVER_BASE_URL:http://localhost:8000}
   timeout-seconds: ${AI_SERVER_TIMEOUT:10}
+
+fcm:
+  service-account-path: ${FCM_SERVICE_ACCOUNT_PATH:}
+
+notification:
+  scheduler:
+    cron: "0 0,30 * * * *"
+  default:
+    wake-up-time: "07:00"
+    bed-time: "23:00"

--- a/src/test/java/com/omteam/omt/config/FcmConfigTest.java
+++ b/src/test/java/com/omteam/omt/config/FcmConfigTest.java
@@ -1,6 +1,5 @@
 package com.omteam.omt.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mockStatic;
@@ -20,15 +19,6 @@ class FcmConfigTest {
     @Nested
     @DisplayName("initFirebase")
     class InitFirebase {
-
-        @Test
-        @DisplayName("serviceAccountPath가 null이면 초기화 스킵 - 예외 없음")
-        void noopWhenPathIsNull() throws Exception {
-            FcmConfig config = new FcmConfig();
-            setField(config, "serviceAccountPath", null);
-
-            assertThatNoException().isThrownBy(config::initFirebase);
-        }
 
         @Test
         @DisplayName("serviceAccountPath가 빈 문자열이면 초기화 스킵 - 예외 없음")

--- a/src/test/java/com/omteam/omt/config/FcmConfigTest.java
+++ b/src/test/java/com/omteam/omt/config/FcmConfigTest.java
@@ -1,0 +1,88 @@
+package com.omteam.omt.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mockStatic;
+
+import com.google.firebase.FirebaseApp;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+@DisplayName("[단위] FcmConfig")
+class FcmConfigTest {
+
+    @Nested
+    @DisplayName("initFirebase")
+    class InitFirebase {
+
+        @Test
+        @DisplayName("serviceAccountPath가 null이면 초기화 스킵 - 예외 없음")
+        void noopWhenPathIsNull() throws Exception {
+            FcmConfig config = new FcmConfig();
+            setField(config, "serviceAccountPath", null);
+
+            assertThatNoException().isThrownBy(config::initFirebase);
+        }
+
+        @Test
+        @DisplayName("serviceAccountPath가 빈 문자열이면 초기화 스킵 - 예외 없음")
+        void noopWhenPathIsBlank() throws Exception {
+            FcmConfig config = new FcmConfig();
+            setField(config, "serviceAccountPath", "");
+
+            assertThatNoException().isThrownBy(config::initFirebase);
+        }
+
+        @Test
+        @DisplayName("serviceAccountPath가 공백이면 초기화 스킵 - 예외 없음")
+        void noopWhenPathIsWhitespace() throws Exception {
+            FcmConfig config = new FcmConfig();
+            setField(config, "serviceAccountPath", "   ");
+
+            assertThatNoException().isThrownBy(config::initFirebase);
+        }
+
+        @Test
+        @DisplayName("Firebase가 이미 초기화된 상태면 재초기화 스킵")
+        void skipWhenAlreadyInitialized() throws Exception {
+            FcmConfig config = new FcmConfig();
+            setField(config, "serviceAccountPath", "/some/path.json");
+
+            try (MockedStatic<FirebaseApp> mockedFirebaseApp = mockStatic(FirebaseApp.class)) {
+                mockedFirebaseApp.when(FirebaseApp::getApps)
+                        .thenReturn(List.of(org.mockito.Mockito.mock(FirebaseApp.class)));
+
+                // Firebase 이미 초기화 상태 - initFirebase 스킵해야 함
+                // 파일이 없어도 예외 없이 리턴
+                assertThatNoException().isThrownBy(config::initFirebase);
+            }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 파일 경로면 IllegalStateException 발생")
+        void throwsWhenFileNotFound() throws Exception {
+            FcmConfig config = new FcmConfig();
+            setField(config, "serviceAccountPath", "/nonexistent/path/service-account.json");
+
+            try (MockedStatic<FirebaseApp> mockedFirebaseApp = mockStatic(FirebaseApp.class)) {
+                mockedFirebaseApp.when(FirebaseApp::getApps).thenReturn(Collections.emptyList());
+
+                assertThatThrownBy(config::initFirebase)
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("Firebase initialization failed");
+            }
+        }
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/java/com/omteam/omt/notification/service/FcmServiceTest.java
+++ b/src/test/java/com/omteam/omt/notification/service/FcmServiceTest.java
@@ -1,0 +1,129 @@
+package com.omteam.omt.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.omteam.omt.common.exception.BusinessException;
+import com.omteam.omt.common.exception.ErrorCode;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[단위] FcmService")
+class FcmServiceTest {
+
+    final FcmService fcmService = new FcmService();
+
+    @Nested
+    @DisplayName("sendNotification")
+    class SendNotification {
+
+        @Test
+        @DisplayName("Firebase 미초기화 시 noop - 예외 없이 리턴")
+        void noop_whenFirebaseNotInitialized() {
+            try (MockedStatic<FirebaseApp> mockedFirebaseApp = mockStatic(FirebaseApp.class)) {
+                mockedFirebaseApp.when(FirebaseApp::getApps).thenReturn(Collections.emptyList());
+
+                // when & then - 예외 없이 정상 종료
+                fcmService.sendNotification("some-token", "제목", "본문");
+            }
+        }
+
+        @Test
+        @DisplayName("null 토큰 시 noop - 예외 없이 리턴")
+        void noop_whenTokenIsNull() throws FirebaseMessagingException {
+            try (MockedStatic<FirebaseApp> mockedFirebaseApp = mockStatic(FirebaseApp.class);
+                 MockedStatic<FirebaseMessaging> mockedMessaging = mockStatic(FirebaseMessaging.class)) {
+
+                mockedFirebaseApp.when(FirebaseApp::getApps).thenReturn(List.of(org.mockito.Mockito.mock(FirebaseApp.class)));
+                FirebaseMessaging mockMessaging = org.mockito.Mockito.mock(FirebaseMessaging.class);
+                mockedMessaging.when(FirebaseMessaging::getInstance).thenReturn(mockMessaging);
+
+                // when & then
+                fcmService.sendNotification(null, "제목", "본문");
+
+                verify(mockMessaging, never()).send(any(Message.class));
+            }
+        }
+
+        @Test
+        @DisplayName("빈 토큰 시 noop - 예외 없이 리턴")
+        void noop_whenTokenIsBlank() throws FirebaseMessagingException {
+            try (MockedStatic<FirebaseApp> mockedFirebaseApp = mockStatic(FirebaseApp.class);
+                 MockedStatic<FirebaseMessaging> mockedMessaging = mockStatic(FirebaseMessaging.class)) {
+
+                mockedFirebaseApp.when(FirebaseApp::getApps).thenReturn(List.of(org.mockito.Mockito.mock(FirebaseApp.class)));
+                FirebaseMessaging mockMessaging = org.mockito.Mockito.mock(FirebaseMessaging.class);
+                mockedMessaging.when(FirebaseMessaging::getInstance).thenReturn(mockMessaging);
+
+                // when & then
+                fcmService.sendNotification("   ", "제목", "본문");
+
+                verify(mockMessaging, never()).send(any(Message.class));
+            }
+        }
+
+        @Test
+        @DisplayName("성공 - messageId 반환")
+        void success_sendMessage() throws FirebaseMessagingException {
+            try (MockedStatic<FirebaseApp> mockedFirebaseApp = mockStatic(FirebaseApp.class);
+                 MockedStatic<FirebaseMessaging> mockedMessaging = mockStatic(FirebaseMessaging.class)) {
+
+                mockedFirebaseApp.when(FirebaseApp::getApps).thenReturn(List.of(org.mockito.Mockito.mock(FirebaseApp.class)));
+                FirebaseMessaging mockMessaging = org.mockito.Mockito.mock(FirebaseMessaging.class);
+                mockedMessaging.when(FirebaseMessaging::getInstance).thenReturn(mockMessaging);
+                given(mockMessaging.send(any(Message.class))).willReturn("projects/test/messages/12345");
+
+                // when & then - 예외 없이 정상 종료
+                fcmService.sendNotification("valid-token", "알림 제목", "알림 본문");
+
+                verify(mockMessaging).send(any(Message.class));
+            }
+        }
+
+        @Test
+        @DisplayName("FirebaseMessagingException 발생 시 FCM_SEND_FAILED 예외")
+        void throwsFcmSendFailed_onFirebaseException() throws FirebaseMessagingException {
+            try (MockedStatic<FirebaseApp> mockedFirebaseApp = mockStatic(FirebaseApp.class);
+                 MockedStatic<FirebaseMessaging> mockedMessaging = mockStatic(FirebaseMessaging.class)) {
+
+                mockedFirebaseApp.when(FirebaseApp::getApps).thenReturn(List.of(org.mockito.Mockito.mock(FirebaseApp.class)));
+                FirebaseMessaging mockMessaging = org.mockito.Mockito.mock(FirebaseMessaging.class);
+                mockedMessaging.when(FirebaseMessaging::getInstance).thenReturn(mockMessaging);
+
+                FirebaseMessagingException exception = org.mockito.Mockito.mock(FirebaseMessagingException.class);
+                given(mockMessaging.send(any(Message.class))).willThrow(exception);
+
+                // when & then
+                assertThatThrownBy(() -> fcmService.sendNotification("invalid-token", "제목", "본문"))
+                        .isInstanceOf(BusinessException.class)
+                        .extracting(e -> ((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.FCM_SEND_FAILED);
+            }
+        }
+
+        @Test
+        @DisplayName("FCM_SEND_FAILED 에러코드 검증 - N001, 500")
+        void fcmSendFailedErrorCode() {
+            assertThat(ErrorCode.FCM_SEND_FAILED.getCode()).isEqualTo("N001");
+            assertThat(ErrorCode.FCM_SEND_FAILED.getStatus())
+                    .isEqualTo(org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR);
+            assertThat(ErrorCode.FCM_SEND_FAILED.getMessage()).isEqualTo("푸시 알림 전송에 실패했습니다");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `build.gradle`에 `firebase-admin:9.4.3` 의존성 추가
- `application.yaml`에 FCM 서비스 계정 경로 및 알림 스케줄러 설정 추가
- `ErrorCode`에 `FCM_SEND_FAILED(N001, 500)` 추가
- `FcmConfig`: `@PostConstruct`로 Firebase Admin SDK 초기화, `FCM_SERVICE_ACCOUNT_PATH` 미설정 시 noop 처리
- `FcmService`: 단건 FCM 발송, null/blank 토큰 noop, `FirebaseMessagingException` → `FCM_SEND_FAILED` 예외 변환

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `build.gradle` | `firebase-admin:9.4.3` 의존성 추가 |
| `application.yaml` | `fcm.service-account-path`, `notification.*` 설정 추가 |
| `ErrorCode.java` | `FCM_SEND_FAILED(N001)` 추가 |
| `config/FcmConfig.java` | Firebase Admin SDK 초기화 (신규) |
| `notification/service/FcmService.java` | FCM 메시지 발송 서비스 (신규) |

## Technical Notes
- 서비스 계정 키는 환경변수 `FCM_SERVICE_ACCOUNT_PATH`로 관리 (`.gitignore` 대상)
- `FCM_SERVICE_ACCOUNT_PATH` 미설정(빈 문자열) → Firebase 초기화 스킵, `FcmService.sendNotification()` noop 동작
- Firebase 중복 초기화 방지: `FirebaseApp.getApps().isEmpty()` 체크
- `FirebaseMessagingException` 발생 시 에러코드와 무관하게 `FCM_SEND_FAILED`로 변환

## Test plan
- [x] `FcmServiceTest` - 5개 테스트 (noop/성공/예외 케이스, 에러코드 검증)
- [x] `FcmConfigTest` - 5개 테스트 (null/blank/whitespace path noop, 이미 초기화됨 스킵, 잘못된 경로 예외)
- [x] 전체 빌드 통과

Closes #109