### PR TITLE
[FEAT] FCM 토큰 등록/삭제 API 및 로그아웃 연동

### DIFF
--- a/src/main/java/com/omteam/omt/notification/controller/NotificationController.java
+++ b/src/main/java/com/omteam/omt/notification/controller/NotificationController.java
@@ -1,0 +1,50 @@
+package com.omteam.omt.notification.controller;
+
+import com.omteam.omt.common.response.ApiResponse;
+import com.omteam.omt.notification.dto.FcmTokenRequest;
+import com.omteam.omt.notification.service.NotificationService;
+import com.omteam.omt.security.principal.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "알림", description = "FCM 토큰 관리 API")
+@RestController
+@RequestMapping("/api/notification")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(
+            summary = "FCM 토큰 등록/갱신",
+            description = "디바이스의 FCM 토큰을 서버에 등록하거나 갱신합니다."
+    )
+    @PutMapping("/fcm-token")
+    public ApiResponse<Void> registerFcmToken(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody FcmTokenRequest request
+    ) {
+        notificationService.registerFcmToken(userPrincipal.userId(), request.getFcmToken());
+        return ApiResponse.success(null);
+    }
+
+    @Operation(
+            summary = "FCM 토큰 삭제",
+            description = "서버에 등록된 FCM 토큰을 삭제합니다. 로그아웃 또는 알림 비활성화 시 사용합니다."
+    )
+    @DeleteMapping("/fcm-token")
+    public ApiResponse<Void> deleteFcmToken(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        notificationService.deleteFcmToken(userPrincipal.userId());
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/omteam/omt/notification/dto/FcmTokenRequest.java
+++ b/src/main/java/com/omteam/omt/notification/dto/FcmTokenRequest.java
@@ -1,0 +1,18 @@
+package com.omteam.omt.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "FCM 토큰 등록 요청")
+public class FcmTokenRequest {
+
+    @Schema(description = "FCM 디바이스 토큰", example = "eX4mPl3T0k3n...")
+    @NotBlank(message = "FCM 토큰은 필수입니다")
+    private String fcmToken;
+}

--- a/src/main/java/com/omteam/omt/notification/service/NotificationService.java
+++ b/src/main/java/com/omteam/omt/notification/service/NotificationService.java
@@ -1,0 +1,26 @@
+package com.omteam.omt.notification.service;
+
+import com.omteam.omt.user.domain.User;
+import com.omteam.omt.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final UserQueryService userQueryService;
+
+    @Transactional
+    public void registerFcmToken(Long userId, String fcmToken) {
+        User user = userQueryService.getUser(userId);
+        user.updateFcmToken(fcmToken);
+    }
+
+    @Transactional
+    public void deleteFcmToken(Long userId) {
+        User user = userQueryService.getUser(userId);
+        user.updateFcmToken(null);
+    }
+}

--- a/src/main/java/com/omteam/omt/security/auth/service/AuthService.java
+++ b/src/main/java/com/omteam/omt/security/auth/service/AuthService.java
@@ -39,7 +39,11 @@ public class AuthService {
         return createLoginResponse(user);
     }
 
+    @Transactional
     public void logout(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        user.updateFcmToken(null);
         refreshTokenService.deleteRefreshToken(userId);
     }
 
@@ -74,6 +78,7 @@ public class AuthService {
             throw new BusinessException(ErrorCode.USER_ALREADY_WITHDRAWN);
         }
 
+        user.updateFcmToken(null);
         user.withdraw();
         refreshTokenService.deleteRefreshToken(userId);
     }

--- a/src/test/java/com/omteam/omt/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/omteam/omt/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,112 @@
+package com.omteam.omt.notification.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+
+import com.omteam.omt.common.response.ApiResponse;
+import com.omteam.omt.notification.dto.FcmTokenRequest;
+import com.omteam.omt.notification.service.NotificationService;
+import com.omteam.omt.security.principal.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[단위] NotificationController")
+class NotificationControllerTest {
+
+    @Mock
+    NotificationService notificationService;
+
+    @InjectMocks
+    NotificationController notificationController;
+
+    UserPrincipal principal;
+
+    @BeforeEach
+    void setUp() {
+        principal = new UserPrincipal(1L);
+    }
+
+    @Nested
+    @DisplayName("PUT /api/notification/fcm-token - FCM 토큰 등록/갱신")
+    class RegisterFcmToken {
+
+        @Test
+        @DisplayName("성공 - FCM 토큰이 등록된다")
+        void success() {
+            // given
+            FcmTokenRequest request = new FcmTokenRequest();
+            request.setFcmToken("valid-fcm-token");
+
+            willDoNothing().given(notificationService).registerFcmToken(1L, "valid-fcm-token");
+
+            // when
+            ApiResponse<Void> result = notificationController.registerFcmToken(principal, request);
+
+            // then
+            assertThat(result.success()).isTrue();
+            assertThat(result.data()).isNull();
+            then(notificationService).should().registerFcmToken(1L, "valid-fcm-token");
+        }
+
+        @Test
+        @DisplayName("성공 - 긴 FCM 토큰도 등록된다")
+        void success_longToken() {
+            // given
+            String longToken = "a".repeat(512);
+            FcmTokenRequest request = new FcmTokenRequest();
+            request.setFcmToken(longToken);
+
+            willDoNothing().given(notificationService).registerFcmToken(1L, longToken);
+
+            // when
+            ApiResponse<Void> result = notificationController.registerFcmToken(principal, request);
+
+            // then
+            assertThat(result.success()).isTrue();
+            then(notificationService).should().registerFcmToken(1L, longToken);
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/notification/fcm-token - FCM 토큰 삭제")
+    class DeleteFcmToken {
+
+        @Test
+        @DisplayName("성공 - FCM 토큰이 삭제된다")
+        void success() {
+            // given
+            willDoNothing().given(notificationService).deleteFcmToken(1L);
+
+            // when
+            ApiResponse<Void> result = notificationController.deleteFcmToken(principal);
+
+            // then
+            assertThat(result.success()).isTrue();
+            assertThat(result.data()).isNull();
+            then(notificationService).should().deleteFcmToken(1L);
+        }
+
+        @Test
+        @DisplayName("성공 - 다른 userId로 호출 시 해당 사용자 토큰이 삭제된다")
+        void success_differentUser() {
+            // given
+            UserPrincipal otherPrincipal = new UserPrincipal(99L);
+            willDoNothing().given(notificationService).deleteFcmToken(99L);
+
+            // when
+            ApiResponse<Void> result = notificationController.deleteFcmToken(otherPrincipal);
+
+            // then
+            assertThat(result.success()).isTrue();
+            then(notificationService).should().deleteFcmToken(99L);
+        }
+    }
+}

--- a/src/test/java/com/omteam/omt/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/omteam/omt/notification/service/NotificationServiceTest.java
@@ -1,0 +1,146 @@
+package com.omteam.omt.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.omteam.omt.common.exception.BusinessException;
+import com.omteam.omt.common.exception.ErrorCode;
+import com.omteam.omt.user.domain.User;
+import com.omteam.omt.user.service.UserQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[단위] NotificationService")
+class NotificationServiceTest {
+
+    @Mock
+    UserQueryService userQueryService;
+
+    @InjectMocks
+    NotificationService notificationService;
+
+    final Long userId = 1L;
+
+    @Nested
+    @DisplayName("registerFcmToken - FCM 토큰 등록/갱신")
+    class RegisterFcmToken {
+
+        @Test
+        @DisplayName("성공 - FCM 토큰이 사용자에게 저장된다")
+        void success() {
+            // given
+            User user = createUser();
+            given(userQueryService.getUser(userId)).willReturn(user);
+
+            // when
+            notificationService.registerFcmToken(userId, "new-fcm-token");
+
+            // then
+            assertThat(user.getFcmToken()).isEqualTo("new-fcm-token");
+            then(userQueryService).should().getUser(userId);
+        }
+
+        @Test
+        @DisplayName("성공 - 기존 토큰이 있어도 새 토큰으로 갱신된다")
+        void success_updateExistingToken() {
+            // given
+            User user = createUserWithFcmToken("old-token");
+            given(userQueryService.getUser(userId)).willReturn(user);
+
+            // when
+            notificationService.registerFcmToken(userId, "new-token");
+
+            // then
+            assertThat(user.getFcmToken()).isEqualTo("new-token");
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자를 찾을 수 없으면 USER_NOT_FOUND 예외")
+        void fail_userNotFound() {
+            // given
+            given(userQueryService.getUser(userId))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.registerFcmToken(userId, "token"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteFcmToken - FCM 토큰 삭제")
+    class DeleteFcmToken {
+
+        @Test
+        @DisplayName("성공 - FCM 토큰이 null로 초기화된다")
+        void success() {
+            // given
+            User user = createUserWithFcmToken("existing-token");
+            given(userQueryService.getUser(userId)).willReturn(user);
+
+            // when
+            notificationService.deleteFcmToken(userId);
+
+            // then
+            assertThat(user.getFcmToken()).isNull();
+            then(userQueryService).should().getUser(userId);
+        }
+
+        @Test
+        @DisplayName("성공 - 토큰이 없어도 예외 없이 null로 설정된다")
+        void success_noExistingToken() {
+            // given
+            User user = createUser();
+            given(userQueryService.getUser(userId)).willReturn(user);
+
+            // when
+            notificationService.deleteFcmToken(userId);
+
+            // then
+            assertThat(user.getFcmToken()).isNull();
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자를 찾을 수 없으면 USER_NOT_FOUND 예외")
+        void fail_userNotFound() {
+            // given
+            given(userQueryService.getUser(userId))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.deleteFcmToken(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    /* ======================== */
+    /* ===== Helper Zone ====== */
+    /* ======================== */
+
+    private User createUser() {
+        return User.builder()
+                .userId(userId)
+                .email("test@example.com")
+                .build();
+    }
+
+    private User createUserWithFcmToken(String fcmToken) {
+        return User.builder()
+                .userId(userId)
+                .email("test@example.com")
+                .fcmToken(fcmToken)
+                .build();
+    }
+}

--- a/src/test/java/com/omteam/omt/security/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/omteam/omt/security/auth/service/AuthServiceTest.java
@@ -130,16 +130,33 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("로그아웃 성공")
+    @DisplayName("로그아웃 성공 - FCM 토큰 초기화 및 Refresh 토큰 삭제")
     void logout_success() {
         // given
         Long userId = 1L;
+        User user = createUser(true);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
         authService.logout(userId);
 
         // then
+        assertThat(user.getFcmToken()).isNull();
         then(refreshTokenService).should().deleteRefreshToken(userId);
+    }
+
+    @Test
+    @DisplayName("로그아웃 실패 - 사용자를 찾을 수 없음")
+    void logout_fail_userNotFound() {
+        // given
+        Long userId = 1L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.logout(userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
     }
 
     @Test
@@ -218,17 +235,19 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("회원 탈퇴 성공")
+    @DisplayName("회원 탈퇴 성공 - FCM 토큰 초기화, soft delete, Refresh 토큰 삭제")
     void withdraw_success() {
         // given
         Long userId = 1L;
-        User user = createUser(true);
+        User user = createUserWithFcmToken("some-fcm-token");
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         // when
         authService.withdraw(userId);
 
         // then
+        assertThat(user.getFcmToken()).isNull();
+        assertThat(user.getDeletedAt()).isNotNull();
         then(userRepository).should().findById(userId);
         then(refreshTokenService).should().deleteRefreshToken(userId);
     }
@@ -286,6 +305,15 @@ class AuthServiceTest {
                 .userId(1L)
                 .email(email)
                 .onboardingCompleted(onboardingCompleted)
+                .build();
+    }
+
+    private User createUserWithFcmToken(String fcmToken) {
+        return User.builder()
+                .userId(1L)
+                .email(email)
+                .onboardingCompleted(true)
+                .fcmToken(fcmToken)
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- `PUT /api/notification/fcm-token` - FCM 토큰 등록/갱신 (upsert 방식)
- `DELETE /api/notification/fcm-token` - FCM 토큰 삭제 (null 초기화)
- `AuthService.logout()` - `@Transactional` 추가, `user.updateFcmToken(null)` 호출로 로그아웃 시 FCM 토큰 초기화
- `AuthService.withdraw()` - 탈퇴 시 `user.updateFcmToken(null)` 호출

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `notification/dto/FcmTokenRequest.java` | FCM 토큰 요청 DTO (`@NotBlank` 검증) |
| `notification/service/NotificationService.java` | `registerFcmToken`, `deleteFcmToken` 구현 |
| `notification/controller/NotificationController.java` | PUT/DELETE 엔드포인트, Swagger 문서화 |
| `security/auth/service/AuthService.java` | `logout()` `@Transactional` 추가 + FCM 토큰 초기화, `withdraw()` FCM 토큰 초기화 |

## Test plan
- [x] `NotificationControllerTest` - PUT/DELETE 엔드포인트 단위 테스트 4개
- [x] `NotificationServiceTest` - registerFcmToken/deleteFcmToken 단위 테스트 6개
- [x] `AuthServiceTest` - logout FCM 초기화 검증, logout 실패(사용자 없음), withdraw FCM 초기화 검증 추가
- [x] 전체 빌드 통과

Closes #110