### PR TITLE
[FEAT] 푸시 알림 스케줄러 구현 (리마인드/체크인/회고)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -139,6 +139,25 @@ jobs:
           strip_components: 0
           overwrite: true
 
+      - name: FCM 서비스 계정 파일 설정
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          envs: FCM_SERVICE_ACCOUNT_JSON
+          script: |
+            mkdir -p /home/${{ secrets.EC2_USERNAME }}/omt/config
+            if [ -n "$FCM_SERVICE_ACCOUNT_JSON" ]; then
+              echo "$FCM_SERVICE_ACCOUNT_JSON" > /home/${{ secrets.EC2_USERNAME }}/omt/config/firebase-service-account.json
+              chmod 600 /home/${{ secrets.EC2_USERNAME }}/omt/config/firebase-service-account.json
+              echo "FCM 서비스 계정 파일 설정 완료"
+            else
+              echo "FCM_SERVICE_ACCOUNT_JSON 시크릿 미설정 - FCM 알림 비활성화됨"
+            fi
+        env:
+          FCM_SERVICE_ACCOUNT_JSON: ${{ secrets.FCM_SERVICE_ACCOUNT_JSON }}
+
       - name: SSH로 EC2 배포 실행
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -150,6 +169,14 @@ jobs:
 
             # certbot 및 certs 디렉토리 생성
             mkdir -p certbot/www certs
+
+            # FCM 서비스 계정 파일 경로 결정
+            FCM_KEY_FILE="/home/${{ secrets.EC2_USERNAME }}/omt/config/firebase-service-account.json"
+            if [ -f "$FCM_KEY_FILE" ]; then
+              FCM_HOST_PATH="$FCM_KEY_FILE"
+            else
+              FCM_HOST_PATH="/dev/null"
+            fi
 
             # .env 파일 생성
             cat > .env << 'ENVEOF'
@@ -175,6 +202,7 @@ jobs:
             LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}
             LANGSMITH_PROJECT=${{ secrets.LANGSMITH_PROJECT }}
             ENVEOF
+            echo "FCM_SERVICE_ACCOUNT_HOST_PATH=$FCM_HOST_PATH" >> .env
 
             # 기존 컨테이너 중지
             docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile prod down --timeout 30 || true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,6 +21,9 @@ services:
       - OAUTH_KAKAO_TEST_CLIENT_ID=${OAUTH_KAKAO_TEST_CLIENT_ID}
       - OAUTH_APPLE_CLIENT_ID=${OAUTH_APPLE_CLIENT_ID}
       - AI_SERVER_BASE_URL=${AI_SERVER_BASE_URL:-http://omt-ai:8000}
+      - FCM_SERVICE_ACCOUNT_PATH=/app/config/firebase-service-account.json
+    volumes:
+      - ${FCM_SERVICE_ACCOUNT_HOST_PATH:-/dev/null}:/app/config/firebase-service-account.json:ro
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - OAUTH_KAKAO_TEST_CLIENT_ID=${OAUTH_KAKAO_TEST_CLIENT_ID}
       - OAUTH_APPLE_CLIENT_ID=${OAUTH_APPLE_CLIENT_ID}
       - AI_SERVER_BASE_URL=${AI_SERVER_BASE_URL:-http://omt-ai:8000}
+      - FCM_SERVICE_ACCOUNT_PATH=${FCM_SERVICE_ACCOUNT_PATH:}
     depends_on:
       omt-ai:
         condition: service_started

--- a/src/main/java/com/omteam/omt/config/FcmConfig.java
+++ b/src/main/java/com/omteam/omt/config/FcmConfig.java
@@ -37,8 +37,7 @@ public class FcmConfig {
             FirebaseApp.initializeApp(options);
             log.info("Firebase Admin SDK initialized successfully.");
         } catch (IOException e) {
-            log.error("Failed to initialize Firebase Admin SDK: {}", e.getMessage());
-            throw new IllegalStateException("Firebase initialization failed", e);
+            log.error("Failed to initialize Firebase Admin SDK. FCM push notifications will be disabled: {}", e.getMessage());
         }
     }
 }

--- a/src/main/java/com/omteam/omt/mission/repository/DailyRecommendedMissionRepository.java
+++ b/src/main/java/com/omteam/omt/mission/repository/DailyRecommendedMissionRepository.java
@@ -5,6 +5,7 @@ import com.omteam.omt.mission.domain.RecommendedMissionStatus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -33,6 +34,13 @@ public interface DailyRecommendedMissionRepository extends JpaRepository<DailyRe
 
     boolean existsByUserUserIdAndMissionDateAndStatusIn(
             Long userId, LocalDate missionDate, List<RecommendedMissionStatus> statuses);
+
+    @Query("SELECT DISTINCT drm.user.userId FROM DailyRecommendedMission drm " +
+            "WHERE drm.user.userId IN :userIds AND drm.missionDate = :missionDate AND drm.status IN :statuses")
+    Set<Long> findUserIdsHavingActiveMissions(
+            @Param("userIds") List<Long> userIds,
+            @Param("missionDate") LocalDate missionDate,
+            @Param("statuses") List<RecommendedMissionStatus> statuses);
 
     @Query("SELECT drm FROM DailyRecommendedMission drm " +
             "JOIN FETCH drm.mission " +

--- a/src/main/java/com/omteam/omt/notification/constant/NotificationMessages.java
+++ b/src/main/java/com/omteam/omt/notification/constant/NotificationMessages.java
@@ -1,0 +1,15 @@
+package com.omteam.omt.notification.constant;
+
+public final class NotificationMessages {
+
+    public static final String REMIND_TITLE = "운동 시간이에요! 💪";
+    public static final String REMIND_BODY = "오늘의 미션을 완료해볼까요? 지금 바로 시작해보세요!";
+
+    public static final String CHECKIN_TITLE = "좋은 아침이에요! ☀️";
+    public static final String CHECKIN_BODY = "오늘 하루도 건강하게 시작해봐요!";
+
+    public static final String REVIEW_TITLE = "오늘 하루는 어땠나요?";
+    public static final String REVIEW_BODY = "오늘의 피드백이 준비됐어요. 확인해보세요!";
+
+    private NotificationMessages() {}
+}

--- a/src/main/java/com/omteam/omt/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/omteam/omt/notification/scheduler/NotificationScheduler.java
@@ -1,0 +1,43 @@
+package com.omteam.omt.notification.scheduler;
+
+import com.omteam.omt.notification.service.NotificationService;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final NotificationService notificationService;
+
+    @Scheduled(cron = "${notification.scheduler.cron}")
+    public void sendScheduledNotifications() {
+        LocalTime now = LocalTime.now().truncatedTo(ChronoUnit.MINUTES);
+        log.info("알림 스케줄러 시작: time={}", now);
+
+        try {
+            notificationService.sendRemindNotifications(now);
+        } catch (Exception e) {
+            log.error("리마인드 알림 스케줄러 오류", e);
+        }
+
+        try {
+            notificationService.sendCheckinNotifications(now);
+        } catch (Exception e) {
+            log.error("체크인 알림 스케줄러 오류", e);
+        }
+
+        try {
+            notificationService.sendReviewNotifications(now);
+        } catch (Exception e) {
+            log.error("회고 알림 스케줄러 오류", e);
+        }
+
+        log.info("알림 스케줄러 완료");
+    }
+}

--- a/src/main/java/com/omteam/omt/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/omteam/omt/notification/scheduler/NotificationScheduler.java
@@ -1,6 +1,7 @@
 package com.omteam.omt.notification.scheduler;
 
 import com.omteam.omt.notification.service.NotificationService;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
@@ -18,10 +19,11 @@ public class NotificationScheduler {
     @Scheduled(cron = "${notification.scheduler.cron}")
     public void sendScheduledNotifications() {
         LocalTime now = LocalTime.now().truncatedTo(ChronoUnit.MINUTES);
+        LocalDate today = LocalDate.now();
         log.info("알림 스케줄러 시작: time={}", now);
 
         try {
-            notificationService.sendRemindNotifications(now);
+            notificationService.sendRemindNotifications(now, today);
         } catch (Exception e) {
             log.error("리마인드 알림 스케줄러 오류", e);
         }
@@ -33,7 +35,7 @@ public class NotificationScheduler {
         }
 
         try {
-            notificationService.sendReviewNotifications(now);
+            notificationService.sendReviewNotifications(now, today);
         } catch (Exception e) {
             log.error("회고 알림 스케줄러 오류", e);
         }

--- a/src/main/java/com/omteam/omt/notification/service/NotificationService.java
+++ b/src/main/java/com/omteam/omt/notification/service/NotificationService.java
@@ -1,16 +1,43 @@
 package com.omteam.omt.notification.service;
 
+import com.omteam.omt.mission.domain.RecommendedMissionStatus;
+import com.omteam.omt.mission.repository.DailyRecommendedMissionRepository;
+import com.omteam.omt.notification.constant.NotificationMessages;
+import com.omteam.omt.report.service.DailyAnalysisService;
 import com.omteam.omt.user.domain.User;
+import com.omteam.omt.user.domain.UserNotificationSetting;
+import com.omteam.omt.user.domain.UserOnboarding;
+import com.omteam.omt.user.repository.UserNotificationSettingRepository;
+import com.omteam.omt.user.repository.UserOnboardingRepository;
 import com.omteam.omt.user.service.UserQueryService;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
     private final UserQueryService userQueryService;
+    private final UserOnboardingRepository userOnboardingRepository;
+    private final UserNotificationSettingRepository notificationSettingRepository;
+    private final DailyRecommendedMissionRepository recommendedMissionRepository;
+    private final DailyAnalysisService dailyAnalysisService;
+    private final FcmService fcmService;
+
+    @Value("${notification.default.wake-up-time}")
+    private String defaultWakeUpTimeStr;
+
+    @Value("${notification.default.bed-time}")
+    private String defaultBedTimeStr;
 
     @Transactional
     public void registerFcmToken(Long userId, String fcmToken) {
@@ -22,5 +49,135 @@ public class NotificationService {
     public void deleteFcmToken(Long userId) {
         User user = userQueryService.getUser(userId);
         user.updateFcmToken(null);
+    }
+
+    public void sendRemindNotifications(LocalTime now) {
+        List<UserOnboarding> targets = userOnboardingRepository.findByAvailableStartTimeForNotification(now);
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        List<Long> userIds = extractUserIds(targets);
+        Map<Long, UserNotificationSetting> settingMap = buildSettingMap(userIds);
+
+        LocalDate today = LocalDate.now();
+        List<RecommendedMissionStatus> activeStatuses = List.of(
+                RecommendedMissionStatus.IN_PROGRESS,
+                RecommendedMissionStatus.COMPLETED
+        );
+
+        int sentCount = 0;
+        for (UserOnboarding onboarding : targets) {
+            User user = onboarding.getUser();
+            Long userId = user.getUserId();
+
+            UserNotificationSetting setting = settingMap.get(userId);
+            if (setting == null || !setting.isRemindEnabled()) {
+                continue;
+            }
+            if (user.getFcmToken() == null || user.getFcmToken().isBlank()) {
+                continue;
+            }
+            if (recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(userId, today, activeStatuses)) {
+                continue;
+            }
+
+            try {
+                fcmService.sendNotification(user.getFcmToken(),
+                        NotificationMessages.REMIND_TITLE,
+                        NotificationMessages.REMIND_BODY);
+                sentCount++;
+            } catch (Exception e) {
+                log.warn("리마인드 알림 발송 실패: userId={}", userId, e);
+            }
+        }
+        log.info("리마인드 알림 발송 완료: total={}, sent={}", targets.size(), sentCount);
+    }
+
+    public void sendCheckinNotifications(LocalTime now) {
+        LocalTime defaultWakeUpTime = LocalTime.parse(defaultWakeUpTimeStr);
+        List<UserOnboarding> targets = userOnboardingRepository.findByEffectiveWakeUpTime(now, defaultWakeUpTime);
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        List<Long> userIds = extractUserIds(targets);
+        Map<Long, UserNotificationSetting> settingMap = buildSettingMap(userIds);
+
+        int sentCount = 0;
+        for (UserOnboarding onboarding : targets) {
+            User user = onboarding.getUser();
+            Long userId = user.getUserId();
+
+            UserNotificationSetting setting = settingMap.get(userId);
+            if (setting == null || !setting.isCheckinEnabled()) {
+                continue;
+            }
+            if (user.getFcmToken() == null || user.getFcmToken().isBlank()) {
+                continue;
+            }
+
+            try {
+                fcmService.sendNotification(user.getFcmToken(),
+                        NotificationMessages.CHECKIN_TITLE,
+                        NotificationMessages.CHECKIN_BODY);
+                sentCount++;
+            } catch (Exception e) {
+                log.warn("체크인 알림 발송 실패: userId={}", userId, e);
+            }
+        }
+        log.info("체크인 알림 발송 완료: total={}, sent={}", targets.size(), sentCount);
+    }
+
+    public void sendReviewNotifications(LocalTime now) {
+        LocalTime defaultBedTime = LocalTime.parse(defaultBedTimeStr);
+        LocalTime defaultReviewTime = defaultBedTime.minusHours(1);
+        LocalTime targetBedTime = now.plusHours(1);
+
+        List<UserOnboarding> targets = userOnboardingRepository.findByBedTimeForReview(
+                targetBedTime, now, defaultReviewTime);
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        List<Long> userIds = extractUserIds(targets);
+        Map<Long, UserNotificationSetting> settingMap = buildSettingMap(userIds);
+
+        LocalDate today = LocalDate.now();
+        int sentCount = 0;
+        for (UserOnboarding onboarding : targets) {
+            User user = onboarding.getUser();
+            Long userId = user.getUserId();
+
+            UserNotificationSetting setting = settingMap.get(userId);
+            if (setting == null || !setting.isReviewEnabled()) {
+                continue;
+            }
+            if (user.getFcmToken() == null || user.getFcmToken().isBlank()) {
+                continue;
+            }
+
+            try {
+                dailyAnalysisService.generateDailyAnalysisForUser(user, today);
+                fcmService.sendNotification(user.getFcmToken(),
+                        NotificationMessages.REVIEW_TITLE,
+                        NotificationMessages.REVIEW_BODY);
+                sentCount++;
+            } catch (Exception e) {
+                log.warn("회고 알림 발송 실패: userId={}", userId, e);
+            }
+        }
+        log.info("회고 알림 발송 완료: total={}, sent={}", targets.size(), sentCount);
+    }
+
+    private List<Long> extractUserIds(List<UserOnboarding> onboardings) {
+        return onboardings.stream()
+                .map(uo -> uo.getUser().getUserId())
+                .collect(Collectors.toList());
+    }
+
+    private Map<Long, UserNotificationSetting> buildSettingMap(List<Long> userIds) {
+        return notificationSettingRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(UserNotificationSetting::getUserId, s -> s));
     }
 }

--- a/src/main/java/com/omteam/omt/notification/service/NotificationService.java
+++ b/src/main/java/com/omteam/omt/notification/service/NotificationService.java
@@ -10,10 +10,13 @@ import com.omteam.omt.user.domain.UserOnboarding;
 import com.omteam.omt.user.repository.UserNotificationSettingRepository;
 import com.omteam.omt.user.repository.UserOnboardingRepository;
 import com.omteam.omt.user.service.UserQueryService;
+import jakarta.annotation.PostConstruct;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +42,15 @@ public class NotificationService {
     @Value("${notification.default.bed-time}")
     private String defaultBedTimeStr;
 
+    private LocalTime defaultWakeUpTime;
+    private LocalTime defaultBedTime;
+
+    @PostConstruct
+    void initDefaultTimes() {
+        defaultWakeUpTime = LocalTime.parse(defaultWakeUpTimeStr);
+        defaultBedTime = LocalTime.parse(defaultBedTimeStr);
+    }
+
     @Transactional
     public void registerFcmToken(Long userId, String fcmToken) {
         User user = userQueryService.getUser(userId);
@@ -51,7 +63,7 @@ public class NotificationService {
         user.updateFcmToken(null);
     }
 
-    public void sendRemindNotifications(LocalTime now) {
+    public void sendRemindNotifications(LocalTime now, LocalDate today) {
         List<UserOnboarding> targets = userOnboardingRepository.findByAvailableStartTimeForNotification(now);
         if (targets.isEmpty()) {
             return;
@@ -60,11 +72,12 @@ public class NotificationService {
         List<Long> userIds = extractUserIds(targets);
         Map<Long, UserNotificationSetting> settingMap = buildSettingMap(userIds);
 
-        LocalDate today = LocalDate.now();
         List<RecommendedMissionStatus> activeStatuses = List.of(
                 RecommendedMissionStatus.IN_PROGRESS,
                 RecommendedMissionStatus.COMPLETED
         );
+        Set<Long> usersWithActiveMissions = new HashSet<>(
+                recommendedMissionRepository.findUserIdsHavingActiveMissions(userIds, today, activeStatuses));
 
         int sentCount = 0;
         for (UserOnboarding onboarding : targets) {
@@ -78,7 +91,7 @@ public class NotificationService {
             if (user.getFcmToken() == null || user.getFcmToken().isBlank()) {
                 continue;
             }
-            if (recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(userId, today, activeStatuses)) {
+            if (usersWithActiveMissions.contains(userId)) {
                 continue;
             }
 
@@ -95,7 +108,6 @@ public class NotificationService {
     }
 
     public void sendCheckinNotifications(LocalTime now) {
-        LocalTime defaultWakeUpTime = LocalTime.parse(defaultWakeUpTimeStr);
         List<UserOnboarding> targets = userOnboardingRepository.findByEffectiveWakeUpTime(now, defaultWakeUpTime);
         if (targets.isEmpty()) {
             return;
@@ -129,8 +141,7 @@ public class NotificationService {
         log.info("체크인 알림 발송 완료: total={}, sent={}", targets.size(), sentCount);
     }
 
-    public void sendReviewNotifications(LocalTime now) {
-        LocalTime defaultBedTime = LocalTime.parse(defaultBedTimeStr);
+    public void sendReviewNotifications(LocalTime now, LocalDate today) {
         LocalTime defaultReviewTime = defaultBedTime.minusHours(1);
         LocalTime targetBedTime = now.plusHours(1);
 
@@ -142,8 +153,6 @@ public class NotificationService {
 
         List<Long> userIds = extractUserIds(targets);
         Map<Long, UserNotificationSetting> settingMap = buildSettingMap(userIds);
-
-        LocalDate today = LocalDate.now();
         int sentCount = 0;
         for (UserOnboarding onboarding : targets) {
             User user = onboarding.getUser();

--- a/src/test/java/com/omteam/omt/config/FcmConfigTest.java
+++ b/src/test/java/com/omteam/omt/config/FcmConfigTest.java
@@ -55,17 +55,15 @@ class FcmConfigTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 파일 경로면 IllegalStateException 발생")
-        void throwsWhenFileNotFound() throws Exception {
+        @DisplayName("존재하지 않는 파일 경로면 예외 없이 FCM 비활성화")
+        void noExceptionWhenFileNotFound() throws Exception {
             FcmConfig config = new FcmConfig();
             setField(config, "serviceAccountPath", "/nonexistent/path/service-account.json");
 
             try (MockedStatic<FirebaseApp> mockedFirebaseApp = mockStatic(FirebaseApp.class)) {
                 mockedFirebaseApp.when(FirebaseApp::getApps).thenReturn(Collections.emptyList());
 
-                assertThatThrownBy(config::initFirebase)
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("Firebase initialization failed");
+                assertThatNoException().isThrownBy(config::initFirebase);
             }
         }
     }

--- a/src/test/java/com/omteam/omt/notification/scheduler/NotificationSchedulerTest.java
+++ b/src/test/java/com/omteam/omt/notification/scheduler/NotificationSchedulerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 
 import com.omteam.omt.notification.service.NotificationService;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,17 +34,17 @@ class NotificationSchedulerTest {
         @DisplayName("3가지 알림 모두 정상 호출된다")
         void success_allNotificationsCalled() {
             // given
-            willDoNothing().given(notificationService).sendRemindNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendRemindNotifications(any(LocalTime.class), any(LocalDate.class));
             willDoNothing().given(notificationService).sendCheckinNotifications(any(LocalTime.class));
-            willDoNothing().given(notificationService).sendReviewNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendReviewNotifications(any(LocalTime.class), any(LocalDate.class));
 
             // when
             notificationScheduler.sendScheduledNotifications();
 
             // then
-            then(notificationService).should().sendRemindNotifications(any(LocalTime.class));
+            then(notificationService).should().sendRemindNotifications(any(LocalTime.class), any(LocalDate.class));
             then(notificationService).should().sendCheckinNotifications(any(LocalTime.class));
-            then(notificationService).should().sendReviewNotifications(any(LocalTime.class));
+            then(notificationService).should().sendReviewNotifications(any(LocalTime.class), any(LocalDate.class));
         }
 
         @Test
@@ -51,32 +52,32 @@ class NotificationSchedulerTest {
         void remindFails_checkinAndReviewStillCalled() {
             // given
             willThrow(new RuntimeException("리마인드 알림 오류"))
-                    .given(notificationService).sendRemindNotifications(any(LocalTime.class));
+                    .given(notificationService).sendRemindNotifications(any(LocalTime.class), any(LocalDate.class));
             willDoNothing().given(notificationService).sendCheckinNotifications(any(LocalTime.class));
-            willDoNothing().given(notificationService).sendReviewNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendReviewNotifications(any(LocalTime.class), any(LocalDate.class));
 
             // when
             notificationScheduler.sendScheduledNotifications();
 
             // then
             then(notificationService).should().sendCheckinNotifications(any(LocalTime.class));
-            then(notificationService).should().sendReviewNotifications(any(LocalTime.class));
+            then(notificationService).should().sendReviewNotifications(any(LocalTime.class), any(LocalDate.class));
         }
 
         @Test
         @DisplayName("체크인 알림 실패해도 회고 알림이 계속 실행된다")
         void checkinFails_reviewStillCalled() {
             // given
-            willDoNothing().given(notificationService).sendRemindNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendRemindNotifications(any(LocalTime.class), any(LocalDate.class));
             willThrow(new RuntimeException("체크인 알림 오류"))
                     .given(notificationService).sendCheckinNotifications(any(LocalTime.class));
-            willDoNothing().given(notificationService).sendReviewNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendReviewNotifications(any(LocalTime.class), any(LocalDate.class));
 
             // when
             notificationScheduler.sendScheduledNotifications();
 
             // then
-            then(notificationService).should().sendReviewNotifications(any(LocalTime.class));
+            then(notificationService).should().sendReviewNotifications(any(LocalTime.class), any(LocalDate.class));
         }
     }
 }

--- a/src/test/java/com/omteam/omt/notification/scheduler/NotificationSchedulerTest.java
+++ b/src/test/java/com/omteam/omt/notification/scheduler/NotificationSchedulerTest.java
@@ -1,0 +1,82 @@
+package com.omteam.omt.notification.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.omteam.omt.notification.service.NotificationService;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[단위] NotificationScheduler")
+class NotificationSchedulerTest {
+
+    @Mock
+    NotificationService notificationService;
+
+    @InjectMocks
+    NotificationScheduler notificationScheduler;
+
+    @Nested
+    @DisplayName("sendScheduledNotifications - 알림 스케줄러 실행")
+    class SendScheduledNotifications {
+
+        @Test
+        @DisplayName("3가지 알림 모두 정상 호출된다")
+        void success_allNotificationsCalled() {
+            // given
+            willDoNothing().given(notificationService).sendRemindNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendCheckinNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendReviewNotifications(any(LocalTime.class));
+
+            // when
+            notificationScheduler.sendScheduledNotifications();
+
+            // then
+            then(notificationService).should().sendRemindNotifications(any(LocalTime.class));
+            then(notificationService).should().sendCheckinNotifications(any(LocalTime.class));
+            then(notificationService).should().sendReviewNotifications(any(LocalTime.class));
+        }
+
+        @Test
+        @DisplayName("리마인드 알림 실패해도 체크인, 회고 알림이 계속 실행된다")
+        void remindFails_checkinAndReviewStillCalled() {
+            // given
+            willThrow(new RuntimeException("리마인드 알림 오류"))
+                    .given(notificationService).sendRemindNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendCheckinNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendReviewNotifications(any(LocalTime.class));
+
+            // when
+            notificationScheduler.sendScheduledNotifications();
+
+            // then
+            then(notificationService).should().sendCheckinNotifications(any(LocalTime.class));
+            then(notificationService).should().sendReviewNotifications(any(LocalTime.class));
+        }
+
+        @Test
+        @DisplayName("체크인 알림 실패해도 회고 알림이 계속 실행된다")
+        void checkinFails_reviewStillCalled() {
+            // given
+            willDoNothing().given(notificationService).sendRemindNotifications(any(LocalTime.class));
+            willThrow(new RuntimeException("체크인 알림 오류"))
+                    .given(notificationService).sendCheckinNotifications(any(LocalTime.class));
+            willDoNothing().given(notificationService).sendReviewNotifications(any(LocalTime.class));
+
+            // when
+            notificationScheduler.sendScheduledNotifications();
+
+            // then
+            then(notificationService).should().sendReviewNotifications(any(LocalTime.class));
+        }
+    }
+}

--- a/src/test/java/com/omteam/omt/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/omteam/omt/notification/service/NotificationServiceTest.java
@@ -29,6 +29,7 @@ import com.omteam.omt.user.service.UserQueryService;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -70,6 +71,8 @@ class NotificationServiceTest {
     void setUp() {
         ReflectionTestUtils.setField(notificationService, "defaultWakeUpTimeStr", "07:00");
         ReflectionTestUtils.setField(notificationService, "defaultBedTimeStr", "23:00");
+        ReflectionTestUtils.setField(notificationService, "defaultWakeUpTime", LocalTime.of(7, 0));
+        ReflectionTestUtils.setField(notificationService, "defaultBedTime", LocalTime.of(23, 0));
     }
 
     // =========================================================
@@ -185,6 +188,7 @@ class NotificationServiceTest {
     class SendRemindNotifications {
 
         final LocalTime now = LocalTime.of(9, 0);
+        final LocalDate today = LocalDate.of(2026, 2, 25);
 
         @Test
         @DisplayName("성공 - 조건 충족 사용자에게 리마인드 알림이 발송된다")
@@ -198,13 +202,11 @@ class NotificationServiceTest {
                     .willReturn(List.of(onboarding));
             given(notificationSettingRepository.findAllById(List.of(userId)))
                     .willReturn(List.of(setting));
-            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
-                    eq(userId), any(LocalDate.class),
-                    eq(List.of(RecommendedMissionStatus.IN_PROGRESS, RecommendedMissionStatus.COMPLETED))))
-                    .willReturn(false);
+            given(recommendedMissionRepository.findUserIdsHavingActiveMissions(anyList(), eq(today), anyList()))
+                    .willReturn(Set.of());
 
             // when
-            notificationService.sendRemindNotifications(now);
+            notificationService.sendRemindNotifications(now, today);
 
             // then
             then(fcmService).should().sendNotification(
@@ -225,9 +227,11 @@ class NotificationServiceTest {
                     .willReturn(List.of(onboarding));
             given(notificationSettingRepository.findAllById(List.of(userId)))
                     .willReturn(List.of(setting));
+            given(recommendedMissionRepository.findUserIdsHavingActiveMissions(anyList(), eq(today), anyList()))
+                    .willReturn(Set.of());
 
             // when
-            notificationService.sendRemindNotifications(now);
+            notificationService.sendRemindNotifications(now, today);
 
             // then
             then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
@@ -245,9 +249,11 @@ class NotificationServiceTest {
                     .willReturn(List.of(onboarding));
             given(notificationSettingRepository.findAllById(List.of(userId)))
                     .willReturn(List.of(setting));
+            given(recommendedMissionRepository.findUserIdsHavingActiveMissions(anyList(), eq(today), anyList()))
+                    .willReturn(Set.of());
 
             // when
-            notificationService.sendRemindNotifications(now);
+            notificationService.sendRemindNotifications(now, today);
 
             // then
             then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
@@ -265,13 +271,11 @@ class NotificationServiceTest {
                     .willReturn(List.of(onboarding));
             given(notificationSettingRepository.findAllById(List.of(userId)))
                     .willReturn(List.of(setting));
-            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
-                    eq(userId), any(LocalDate.class),
-                    eq(List.of(RecommendedMissionStatus.IN_PROGRESS, RecommendedMissionStatus.COMPLETED))))
-                    .willReturn(true);
+            given(recommendedMissionRepository.findUserIdsHavingActiveMissions(anyList(), eq(today), anyList()))
+                    .willReturn(Set.of(userId));
 
             // when
-            notificationService.sendRemindNotifications(now);
+            notificationService.sendRemindNotifications(now, today);
 
             // then
             then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
@@ -289,13 +293,11 @@ class NotificationServiceTest {
                     .willReturn(List.of(onboarding));
             given(notificationSettingRepository.findAllById(List.of(userId)))
                     .willReturn(List.of(setting));
-            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
-                    eq(userId), any(LocalDate.class),
-                    eq(List.of(RecommendedMissionStatus.IN_PROGRESS, RecommendedMissionStatus.COMPLETED))))
-                    .willReturn(true);
+            given(recommendedMissionRepository.findUserIdsHavingActiveMissions(anyList(), eq(today), anyList()))
+                    .willReturn(Set.of(userId));
 
             // when
-            notificationService.sendRemindNotifications(now);
+            notificationService.sendRemindNotifications(now, today);
 
             // then
             then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
@@ -309,7 +311,7 @@ class NotificationServiceTest {
                     .willReturn(List.of());
 
             // when
-            notificationService.sendRemindNotifications(now);
+            notificationService.sendRemindNotifications(now, today);
 
             // then
             then(notificationSettingRepository).should(never()).findAllById(anyList());
@@ -353,12 +355,8 @@ class NotificationServiceTest {
                     .willReturn(List.of(onboarding1, onboarding2));
             given(notificationSettingRepository.findAllById(List.of(userId, 2L)))
                     .willReturn(List.of(setting1, setting2));
-            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
-                    eq(userId), any(LocalDate.class), anyList()))
-                    .willReturn(false);
-            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
-                    eq(2L), any(LocalDate.class), anyList()))
-                    .willReturn(false);
+            given(recommendedMissionRepository.findUserIdsHavingActiveMissions(anyList(), eq(today), anyList()))
+                    .willReturn(Set.of());
 
             willThrow(new RuntimeException("FCM 오류"))
                     .given(fcmService).sendNotification(eq("token-1"), anyString(), anyString());
@@ -366,7 +364,7 @@ class NotificationServiceTest {
                     .given(fcmService).sendNotification(eq("token-2"), anyString(), anyString());
 
             // when
-            notificationService.sendRemindNotifications(now);
+            notificationService.sendRemindNotifications(now, today);
 
             // then
             then(fcmService).should().sendNotification(eq("token-1"), anyString(), anyString());
@@ -500,6 +498,7 @@ class NotificationServiceTest {
         final LocalTime now = LocalTime.of(22, 0);
         final LocalTime targetBedTime = LocalTime.of(23, 0);
         final LocalTime defaultReviewTime = LocalTime.of(22, 0);
+        final LocalDate today = LocalDate.of(2026, 2, 25);
 
         @Test
         @DisplayName("성공 - 분석 생성 후 회고 알림이 발송된다")
@@ -514,13 +513,13 @@ class NotificationServiceTest {
             given(notificationSettingRepository.findAllById(List.of(userId)))
                     .willReturn(List.of(setting));
             willDoNothing()
-                    .given(dailyAnalysisService).generateDailyAnalysisForUser(eq(user), any(LocalDate.class));
+                    .given(dailyAnalysisService).generateDailyAnalysisForUser(eq(user), eq(today));
 
             // when
-            notificationService.sendReviewNotifications(now);
+            notificationService.sendReviewNotifications(now, today);
 
             // then
-            then(dailyAnalysisService).should().generateDailyAnalysisForUser(eq(user), any(LocalDate.class));
+            then(dailyAnalysisService).should().generateDailyAnalysisForUser(eq(user), eq(today));
             then(fcmService).should().sendNotification(
                     "fcm-token",
                     NotificationMessages.REVIEW_TITLE,
@@ -541,7 +540,7 @@ class NotificationServiceTest {
                     .willReturn(List.of(setting));
 
             // when
-            notificationService.sendReviewNotifications(now);
+            notificationService.sendReviewNotifications(now, today);
 
             // then
             then(dailyAnalysisService).should(never()).generateDailyAnalysisForUser(any(), any());
@@ -562,7 +561,7 @@ class NotificationServiceTest {
                     .willReturn(List.of(setting));
 
             // when
-            notificationService.sendReviewNotifications(now);
+            notificationService.sendReviewNotifications(now, today);
 
             // then
             then(dailyAnalysisService).should(never()).generateDailyAnalysisForUser(any(), any());
@@ -577,7 +576,7 @@ class NotificationServiceTest {
                     .willReturn(List.of());
 
             // when
-            notificationService.sendReviewNotifications(now);
+            notificationService.sendReviewNotifications(now, today);
 
             // then
             then(notificationSettingRepository).should(never()).findAllById(anyList());
@@ -598,10 +597,10 @@ class NotificationServiceTest {
             given(notificationSettingRepository.findAllById(List.of(userId)))
                     .willReturn(List.of(setting));
             willThrow(new RuntimeException("AI 분석 실패"))
-                    .given(dailyAnalysisService).generateDailyAnalysisForUser(eq(user), any(LocalDate.class));
+                    .given(dailyAnalysisService).generateDailyAnalysisForUser(eq(user), eq(today));
 
             // when
-            notificationService.sendReviewNotifications(now);
+            notificationService.sendReviewNotifications(now, today);
 
             // then: catch 블록에서 예외를 삼키므로 FCM도 호출되지 않는다
             then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());

--- a/src/test/java/com/omteam/omt/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/omteam/omt/notification/service/NotificationServiceTest.java
@@ -2,13 +2,34 @@ package com.omteam.omt.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 
 import com.omteam.omt.common.exception.BusinessException;
 import com.omteam.omt.common.exception.ErrorCode;
+import com.omteam.omt.mission.domain.RecommendedMissionStatus;
+import com.omteam.omt.mission.repository.DailyRecommendedMissionRepository;
+import com.omteam.omt.notification.constant.NotificationMessages;
+import com.omteam.omt.report.service.DailyAnalysisService;
+import com.omteam.omt.user.domain.LifestyleType;
 import com.omteam.omt.user.domain.User;
+import com.omteam.omt.user.domain.UserNotificationSetting;
+import com.omteam.omt.user.domain.UserOnboarding;
+import com.omteam.omt.user.domain.WorkTimeType;
+import com.omteam.omt.user.repository.UserNotificationSettingRepository;
+import com.omteam.omt.user.repository.UserOnboardingRepository;
 import com.omteam.omt.user.service.UserQueryService;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,6 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("[단위] NotificationService")
@@ -24,10 +46,35 @@ class NotificationServiceTest {
     @Mock
     UserQueryService userQueryService;
 
+    @Mock
+    UserOnboardingRepository userOnboardingRepository;
+
+    @Mock
+    UserNotificationSettingRepository notificationSettingRepository;
+
+    @Mock
+    DailyRecommendedMissionRepository recommendedMissionRepository;
+
+    @Mock
+    DailyAnalysisService dailyAnalysisService;
+
+    @Mock
+    FcmService fcmService;
+
     @InjectMocks
     NotificationService notificationService;
 
     final Long userId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(notificationService, "defaultWakeUpTimeStr", "07:00");
+        ReflectionTestUtils.setField(notificationService, "defaultBedTimeStr", "23:00");
+    }
+
+    // =========================================================
+    // registerFcmToken
+    // =========================================================
 
     @Nested
     @DisplayName("registerFcmToken - FCM 토큰 등록/갱신")
@@ -77,6 +124,10 @@ class NotificationServiceTest {
         }
     }
 
+    // =========================================================
+    // deleteFcmToken
+    // =========================================================
+
     @Nested
     @DisplayName("deleteFcmToken - FCM 토큰 삭제")
     class DeleteFcmToken {
@@ -125,6 +176,438 @@ class NotificationServiceTest {
         }
     }
 
+    // =========================================================
+    // sendRemindNotifications
+    // =========================================================
+
+    @Nested
+    @DisplayName("sendRemindNotifications - 리마인드 알림 발송")
+    class SendRemindNotifications {
+
+        final LocalTime now = LocalTime.of(9, 0);
+
+        @Test
+        @DisplayName("성공 - 조건 충족 사용자에게 리마인드 알림이 발송된다")
+        void success() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboarding(user, now);
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByAvailableStartTimeForNotification(now))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
+                    eq(userId), any(LocalDate.class),
+                    eq(List.of(RecommendedMissionStatus.IN_PROGRESS, RecommendedMissionStatus.COMPLETED))))
+                    .willReturn(false);
+
+            // when
+            notificationService.sendRemindNotifications(now);
+
+            // then
+            then(fcmService).should().sendNotification(
+                    "fcm-token",
+                    NotificationMessages.REMIND_TITLE,
+                    NotificationMessages.REMIND_BODY);
+        }
+
+        @Test
+        @DisplayName("건너뜀 - remindEnabled=false인 경우 알림을 발송하지 않는다")
+        void skip_remindDisabled() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboarding(user, now);
+            UserNotificationSetting setting = createSetting(user, false, true, true);
+
+            given(userOnboardingRepository.findByAvailableStartTimeForNotification(now))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+
+            // when
+            notificationService.sendRemindNotifications(now);
+
+            // then
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("건너뜀 - FCM 토큰이 없는 경우 알림을 발송하지 않는다")
+        void skip_noFcmToken() {
+            // given
+            User user = createUser();
+            UserOnboarding onboarding = createOnboarding(user, now);
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByAvailableStartTimeForNotification(now))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+
+            // when
+            notificationService.sendRemindNotifications(now);
+
+            // then
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("건너뜀 - 오늘 IN_PROGRESS 미션이 있으면 알림을 발송하지 않는다")
+        void skip_inProgressMissionExists() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboarding(user, now);
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByAvailableStartTimeForNotification(now))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
+                    eq(userId), any(LocalDate.class),
+                    eq(List.of(RecommendedMissionStatus.IN_PROGRESS, RecommendedMissionStatus.COMPLETED))))
+                    .willReturn(true);
+
+            // when
+            notificationService.sendRemindNotifications(now);
+
+            // then
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("건너뜀 - 오늘 COMPLETED 미션이 있으면 알림을 발송하지 않는다")
+        void skip_completedMissionExists() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboarding(user, now);
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByAvailableStartTimeForNotification(now))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
+                    eq(userId), any(LocalDate.class),
+                    eq(List.of(RecommendedMissionStatus.IN_PROGRESS, RecommendedMissionStatus.COMPLETED))))
+                    .willReturn(true);
+
+            // when
+            notificationService.sendRemindNotifications(now);
+
+            // then
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("조건 충족 사용자가 없으면 아무것도 하지 않는다")
+        void noTargets_doNothing() {
+            // given
+            given(userOnboardingRepository.findByAvailableStartTimeForNotification(now))
+                    .willReturn(List.of());
+
+            // when
+            notificationService.sendRemindNotifications(now);
+
+            // then
+            then(notificationSettingRepository).should(never()).findAllById(anyList());
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("FCM 전송 실패해도 다음 사용자 처리를 계속한다")
+        void fcmFailure_continuesNextUser() {
+            // given
+            User user1 = createUserWithFcmToken("token-1");
+            User user2 = User.builder()
+                    .userId(2L)
+                    .email("user2@example.com")
+                    .fcmToken("token-2")
+                    .build();
+
+            UserOnboarding onboarding1 = createOnboarding(user1, now);
+            UserOnboarding onboarding2 = UserOnboarding.builder()
+                    .userId(2L)
+                    .user(user2)
+                    .availableStartTime(now)
+                    .availableEndTime(now.plusHours(1))
+                    .appGoalText("목표")
+                    .workTimeType(WorkTimeType.FIXED)
+                    .minExerciseMinutes(30)
+                    .preferredExercises(List.of("달리기"))
+                    .lifestyleType(LifestyleType.REGULAR_DAYTIME)
+                    .build();
+
+            UserNotificationSetting setting1 = createSetting(user1, true, true, true);
+            UserNotificationSetting setting2 = UserNotificationSetting.builder()
+                    .userId(2L)
+                    .user(user2)
+                    .remindEnabled(true)
+                    .checkinEnabled(true)
+                    .reviewEnabled(true)
+                    .build();
+
+            given(userOnboardingRepository.findByAvailableStartTimeForNotification(now))
+                    .willReturn(List.of(onboarding1, onboarding2));
+            given(notificationSettingRepository.findAllById(List.of(userId, 2L)))
+                    .willReturn(List.of(setting1, setting2));
+            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
+                    eq(userId), any(LocalDate.class), anyList()))
+                    .willReturn(false);
+            given(recommendedMissionRepository.existsByUserUserIdAndMissionDateAndStatusIn(
+                    eq(2L), any(LocalDate.class), anyList()))
+                    .willReturn(false);
+
+            willThrow(new RuntimeException("FCM 오류"))
+                    .given(fcmService).sendNotification(eq("token-1"), anyString(), anyString());
+            willDoNothing()
+                    .given(fcmService).sendNotification(eq("token-2"), anyString(), anyString());
+
+            // when
+            notificationService.sendRemindNotifications(now);
+
+            // then
+            then(fcmService).should().sendNotification(eq("token-1"), anyString(), anyString());
+            then(fcmService).should().sendNotification(eq("token-2"), anyString(), anyString());
+        }
+    }
+
+    // =========================================================
+    // sendCheckinNotifications
+    // =========================================================
+
+    @Nested
+    @DisplayName("sendCheckinNotifications - 체크인 알림 발송")
+    class SendCheckinNotifications {
+
+        final LocalTime now = LocalTime.of(7, 0);
+        final LocalTime defaultWakeUpTime = LocalTime.of(7, 0);
+
+        @Test
+        @DisplayName("성공 - 조건 충족 사용자에게 체크인 알림이 발송된다")
+        void success() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboardingWithWakeUpTime(user, now);
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByEffectiveWakeUpTime(now, defaultWakeUpTime))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+
+            // when
+            notificationService.sendCheckinNotifications(now);
+
+            // then
+            then(fcmService).should().sendNotification(
+                    "fcm-token",
+                    NotificationMessages.CHECKIN_TITLE,
+                    NotificationMessages.CHECKIN_BODY);
+        }
+
+        @Test
+        @DisplayName("건너뜀 - checkinEnabled=false인 경우 알림을 발송하지 않는다")
+        void skip_checkinDisabled() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboardingWithWakeUpTime(user, now);
+            UserNotificationSetting setting = createSetting(user, true, false, true);
+
+            given(userOnboardingRepository.findByEffectiveWakeUpTime(now, defaultWakeUpTime))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+
+            // when
+            notificationService.sendCheckinNotifications(now);
+
+            // then
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("건너뜀 - FCM 토큰이 없는 경우 알림을 발송하지 않는다")
+        void skip_noFcmToken() {
+            // given
+            User user = createUser();
+            UserOnboarding onboarding = createOnboardingWithWakeUpTime(user, now);
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByEffectiveWakeUpTime(now, defaultWakeUpTime))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+
+            // when
+            notificationService.sendCheckinNotifications(now);
+
+            // then
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("조건 충족 사용자가 없으면 아무것도 하지 않는다")
+        void noTargets_doNothing() {
+            // given
+            given(userOnboardingRepository.findByEffectiveWakeUpTime(now, defaultWakeUpTime))
+                    .willReturn(List.of());
+
+            // when
+            notificationService.sendCheckinNotifications(now);
+
+            // then
+            then(notificationSettingRepository).should(never()).findAllById(anyList());
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("wakeUpTime=null인 사용자도 기본값(defaultWakeUpTime)으로 조회된다")
+        void nullWakeUpTime_usesDefaultTime() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboarding(user, LocalTime.of(9, 0)); // wakeUpTime=null
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByEffectiveWakeUpTime(defaultWakeUpTime, defaultWakeUpTime))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+
+            // when
+            notificationService.sendCheckinNotifications(defaultWakeUpTime);
+
+            // then
+            then(fcmService).should().sendNotification(
+                    "fcm-token",
+                    NotificationMessages.CHECKIN_TITLE,
+                    NotificationMessages.CHECKIN_BODY);
+        }
+    }
+
+    // =========================================================
+    // sendReviewNotifications
+    // =========================================================
+
+    @Nested
+    @DisplayName("sendReviewNotifications - 회고 알림 발송")
+    class SendReviewNotifications {
+
+        // defaultBedTimeStr="23:00" => defaultReviewTime=22:00
+        // now=22:00 => targetBedTime=23:00
+        final LocalTime now = LocalTime.of(22, 0);
+        final LocalTime targetBedTime = LocalTime.of(23, 0);
+        final LocalTime defaultReviewTime = LocalTime.of(22, 0);
+
+        @Test
+        @DisplayName("성공 - 분석 생성 후 회고 알림이 발송된다")
+        void success() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboardingWithBedTime(user, targetBedTime);
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByBedTimeForReview(targetBedTime, now, defaultReviewTime))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+            willDoNothing()
+                    .given(dailyAnalysisService).generateDailyAnalysisForUser(eq(user), any(LocalDate.class));
+
+            // when
+            notificationService.sendReviewNotifications(now);
+
+            // then
+            then(dailyAnalysisService).should().generateDailyAnalysisForUser(eq(user), any(LocalDate.class));
+            then(fcmService).should().sendNotification(
+                    "fcm-token",
+                    NotificationMessages.REVIEW_TITLE,
+                    NotificationMessages.REVIEW_BODY);
+        }
+
+        @Test
+        @DisplayName("건너뜀 - reviewEnabled=false인 경우 알림을 발송하지 않는다")
+        void skip_reviewDisabled() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboardingWithBedTime(user, targetBedTime);
+            UserNotificationSetting setting = createSetting(user, true, true, false);
+
+            given(userOnboardingRepository.findByBedTimeForReview(targetBedTime, now, defaultReviewTime))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+
+            // when
+            notificationService.sendReviewNotifications(now);
+
+            // then
+            then(dailyAnalysisService).should(never()).generateDailyAnalysisForUser(any(), any());
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("건너뜀 - FCM 토큰이 없는 경우 알림을 발송하지 않는다")
+        void skip_noFcmToken() {
+            // given
+            User user = createUser();
+            UserOnboarding onboarding = createOnboardingWithBedTime(user, targetBedTime);
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByBedTimeForReview(targetBedTime, now, defaultReviewTime))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+
+            // when
+            notificationService.sendReviewNotifications(now);
+
+            // then
+            then(dailyAnalysisService).should(never()).generateDailyAnalysisForUser(any(), any());
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("조건 충족 사용자가 없으면 아무것도 하지 않는다")
+        void noTargets_doNothing() {
+            // given
+            given(userOnboardingRepository.findByBedTimeForReview(targetBedTime, now, defaultReviewTime))
+                    .willReturn(List.of());
+
+            // when
+            notificationService.sendReviewNotifications(now);
+
+            // then
+            then(notificationSettingRepository).should(never()).findAllById(anyList());
+            then(dailyAnalysisService).should(never()).generateDailyAnalysisForUser(any(), any());
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("분석 생성 실패 시 예외를 무시하고 FCM 알림도 발송하지 않는다")
+        void analysisFailure_exceptionIgnoredAndFcmNotSent() {
+            // given
+            User user = createUserWithFcmToken("fcm-token");
+            UserOnboarding onboarding = createOnboardingWithBedTime(user, targetBedTime);
+            UserNotificationSetting setting = createSetting(user, true, true, true);
+
+            given(userOnboardingRepository.findByBedTimeForReview(targetBedTime, now, defaultReviewTime))
+                    .willReturn(List.of(onboarding));
+            given(notificationSettingRepository.findAllById(List.of(userId)))
+                    .willReturn(List.of(setting));
+            willThrow(new RuntimeException("AI 분석 실패"))
+                    .given(dailyAnalysisService).generateDailyAnalysisForUser(eq(user), any(LocalDate.class));
+
+            // when
+            notificationService.sendReviewNotifications(now);
+
+            // then: catch 블록에서 예외를 삼키므로 FCM도 호출되지 않는다
+            then(fcmService).should(never()).sendNotification(anyString(), anyString(), anyString());
+        }
+    }
+
     /* ======================== */
     /* ===== Helper Zone ====== */
     /* ======================== */
@@ -141,6 +624,61 @@ class NotificationServiceTest {
                 .userId(userId)
                 .email("test@example.com")
                 .fcmToken(fcmToken)
+                .build();
+    }
+
+    private UserOnboarding createOnboarding(User user, LocalTime availableStartTime) {
+        return UserOnboarding.builder()
+                .userId(user.getUserId())
+                .user(user)
+                .availableStartTime(availableStartTime)
+                .availableEndTime(availableStartTime.plusHours(1))
+                .appGoalText("목표")
+                .workTimeType(WorkTimeType.FIXED)
+                .minExerciseMinutes(30)
+                .preferredExercises(List.of("달리기"))
+                .lifestyleType(LifestyleType.REGULAR_DAYTIME)
+                .build();
+    }
+
+    private UserOnboarding createOnboardingWithWakeUpTime(User user, LocalTime wakeUpTime) {
+        return UserOnboarding.builder()
+                .userId(user.getUserId())
+                .user(user)
+                .availableStartTime(LocalTime.of(9, 0))
+                .availableEndTime(LocalTime.of(10, 0))
+                .appGoalText("목표")
+                .workTimeType(WorkTimeType.FIXED)
+                .minExerciseMinutes(30)
+                .preferredExercises(List.of("달리기"))
+                .lifestyleType(LifestyleType.REGULAR_DAYTIME)
+                .wakeUpTime(wakeUpTime)
+                .build();
+    }
+
+    private UserOnboarding createOnboardingWithBedTime(User user, LocalTime bedTime) {
+        return UserOnboarding.builder()
+                .userId(user.getUserId())
+                .user(user)
+                .availableStartTime(LocalTime.of(9, 0))
+                .availableEndTime(LocalTime.of(10, 0))
+                .appGoalText("목표")
+                .workTimeType(WorkTimeType.FIXED)
+                .minExerciseMinutes(30)
+                .preferredExercises(List.of("달리기"))
+                .lifestyleType(LifestyleType.REGULAR_DAYTIME)
+                .bedTime(bedTime)
+                .build();
+    }
+
+    private UserNotificationSetting createSetting(
+            User user, boolean remindEnabled, boolean checkinEnabled, boolean reviewEnabled) {
+        return UserNotificationSetting.builder()
+                .userId(user.getUserId())
+                .user(user)
+                .remindEnabled(remindEnabled)
+                .checkinEnabled(checkinEnabled)
+                .reviewEnabled(reviewEnabled)
                 .build();
     }
 }


### PR DESCRIPTION
## Summary

- `NotificationMessages.java` 추가 - 알림 타입별 제목/본문 상수 정의
- `NotificationService.java` 확장 - 리마인드/체크인/회고 알림 전송 메서드 구현
- `NotificationScheduler.java` 추가 - 30분마다 실행되는 스케줄러 (`${notification.scheduler.cron}` 외부화)

## 알림 조건

| 타입 | 트리거 시각 | 추가 조건 |
|------|------------|-----------|
| 리마인드 | `availableStartTime == now` | IN_PROGRESS/COMPLETED 미션 없음, `remindEnabled` |
| 체크인 | `wakeUpTime == now` (null → yml 기본값) | `checkinEnabled` |
| 회고 | `bedTime - 1h == now` (null → 기본값 - 1h) | `reviewEnabled`, `generateDailyAnalysisForUser` 호출 |

## 기술적 사항

- N+1 방지: `UserOnboardingRepository` JOIN FETCH 쿼리 + `findAllById` 배치 조회
- FCM 토큰 없는 사용자 건너뜀
- 각 알림 타입/사용자별 예외 독립 처리 (하나 실패해도 다음 처리 계속)
- 단위 테스트 22개 (NotificationService) + 3개 (NotificationScheduler) 작성

## Test plan

- [ ] `NotificationServiceTest` - 3개 알림 전송 메서드 케이스별 검증 (22개)
- [ ] `NotificationSchedulerTest` - 스케줄러 호출 및 예외 격리 검증 (3개)
- [ ] 빌드 확인: `./gradlew build`

Closes #111