### PR TITLE
[FIX] AI fallback 응답 DB 저장 처리

### DIFF
--- a/src/main/java/com/omteam/omt/chat/service/ChatService.java
+++ b/src/main/java/com/omteam/omt/chat/service/ChatService.java
@@ -125,16 +125,11 @@ public class ChatService {
         AiChatRequest aiRequest = buildAiRequest(userId, session, request);
         AiChatResponse aiResponse = aiChatClient.sendMessage(aiRequest);
 
-        // fallback 응답이면 DB 저장 없이 직접 반환
+        // fallback 응답도 DB에 저장하여 채팅 내역에서 AI 응답이 누락되지 않도록 함
         if (aiResponse.isFallback()) {
             log.info("AI 서버 fallback 응답 반환: userId={}, sessionId={}", userId, session.getId());
-            return ChatMessageResponse.builder()
-                    .messageId(null)
-                    .role(ChatMessageRole.ASSISTANT)
-                    .content(aiResponse.getBotMessage().getText())
-                    .options(List.of())
-                    .isTerminal(false)
-                    .build();
+            ChatMessage fallbackMessage = saveAssistantMessage(session, aiResponse, false);
+            return ChatMessageResponse.from(fallbackMessage, objectMapper, false);
         }
 
         // 대화 종료 여부 판단


### PR DESCRIPTION
## Summary

- AI 서버 장애(Circuit Breaker OPEN, 타임아웃, 연결 실패) 시 fallback 응답이 DB에 저장되지 않아 채팅 내역 조회(`GET /api/chat`)에서 사용자 메시지만 남고 AI 응답이 누락되는 UX 문제 수정
- 기존 `saveAssistantMessage()` 메서드를 재사용하여 fallback 메시지도 ASSISTANT 메시지로 DB에 저장

## Test plan

- [x] `ChatServiceTest` 전체 테스트 통과 확인
- [x] AI 서버 장애 시 fallback 응답("AI 서버 응답이 지연되고 있어요...") 이 DB에 저장되어 채팅 내역에 표시되는지 확인
- [x] 정상 응답 흐름에 영향이 없는지 확인