### PR TITLE
[FEAT] 월간 패턴 API에 특정 주 조회 기능 추가

### DIFF
--- a/src/main/java/com/omteam/omt/report/controller/WeeklyReportController.java
+++ b/src/main/java/com/omteam/omt/report/controller/WeeklyReportController.java
@@ -49,9 +49,16 @@ public class WeeklyReportController {
     @Operation(summary = "월간 요일별 패턴 분석", description = "지난 30일간의 요일별 성공 패턴을 분석하고 AI 피드백을 제공합니다.")
     @GetMapping("/monthly-pattern")
     public ApiResponse<MonthlyPatternResponse> getMonthlyPattern(
-            @AuthenticationPrincipal UserPrincipal principal
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Parameter(description = "연도 (미입력시 이번 주)", example = "2024")
+            @RequestParam(required = false) Integer year,
+            @Parameter(description = "월 (1-12)", example = "1")
+            @RequestParam(required = false) Integer month,
+            @Parameter(description = "해당 월의 주차 (1부터 시작)", example = "3")
+            @RequestParam(required = false) Integer weekOfMonth
     ) {
-        MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(principal.userId());
+        MonthlyPatternResponse response = monthlyPatternService
+                .getMonthlyPattern(principal.userId(), year, month, weekOfMonth);
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/com/omteam/omt/report/service/MonthlyPatternService.java
+++ b/src/main/java/com/omteam/omt/report/service/MonthlyPatternService.java
@@ -1,5 +1,6 @@
 package com.omteam.omt.report.service;
 
+import com.omteam.omt.common.util.DateRangeUtils;
 import com.omteam.omt.common.util.DayOfWeekUtils;
 import com.omteam.omt.common.util.MissionResultStats;
 import com.omteam.omt.mission.domain.DailyMissionResult;
@@ -11,7 +12,6 @@ import com.omteam.omt.report.dto.ReportDataStatus;
 import com.omteam.omt.report.repository.WeeklyAiAnalysisRepository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -34,12 +34,12 @@ public class MonthlyPatternService {
     /**
      * 월간 요일별 패턴 분석
      */
-    public MonthlyPatternResponse getMonthlyPattern(Long userId) {
-        LocalDate today = LocalDate.now();
-        LocalDate monthAgo = today.minusDays(MONTHLY_PATTERN_DAYS);
+    public MonthlyPatternResponse getMonthlyPattern(Long userId, Integer year, Integer month, Integer weekOfMonth) {
+        LocalDate weekStartDate = resolveWeekStartDate(year, month, weekOfMonth);
+        LocalDate startDate = weekStartDate.minusDays(MONTHLY_PATTERN_DAYS);
 
         List<DailyMissionResult> results = missionResultRepository
-                .findByUserUserIdAndMissionDateBetweenOrderByMissionDateDesc(userId, monthAgo, today);
+                .findByUserUserIdAndMissionDateBetweenOrderByMissionDateDesc(userId, startDate, weekStartDate);
 
         boolean hasMissionData = !results.isEmpty();
 
@@ -48,17 +48,24 @@ public class MonthlyPatternService {
 
         List<MonthlyPatternResponse.DayOfWeekStatistics> dayOfWeekStats =
                 buildDayOfWeekStatistics(resultsByDayOfWeek);
-        MonthlyPatternResponse.AiFeedback aiFeedback = getAiFeedback(userId, hasMissionData);
+        MonthlyPatternResponse.AiFeedback aiFeedback = getAiFeedback(userId, hasMissionData, weekStartDate);
 
         ReportDataStatus dataStatus = ReportDataStatus.of(aiFeedback.isDefault(), hasMissionData);
 
         return MonthlyPatternResponse.builder()
                 .dataStatus(dataStatus)
-                .startDate(monthAgo)
-                .endDate(today)
+                .startDate(startDate)
+                .endDate(weekStartDate)
                 .dayOfWeekStats(dayOfWeekStats)
                 .aiFeedback(aiFeedback)
                 .build();
+    }
+
+    private LocalDate resolveWeekStartDate(Integer year, Integer month, Integer weekOfMonth) {
+        if (year == null || month == null || weekOfMonth == null) {
+            return DateRangeUtils.getWeekStartDate(LocalDate.now());
+        }
+        return DateRangeUtils.getWeekStartOfMonth(year, month, weekOfMonth);
     }
 
     private List<MonthlyPatternResponse.DayOfWeekStatistics> buildDayOfWeekStatistics(
@@ -80,11 +87,9 @@ public class MonthlyPatternService {
                 .toList();
     }
 
-    private MonthlyPatternResponse.AiFeedback getAiFeedback(Long userId, boolean hasMissionData) {
-        LocalDate currentWeekMonday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-
+    private MonthlyPatternResponse.AiFeedback getAiFeedback(Long userId, boolean hasMissionData, LocalDate weekStartDate) {
         Optional<WeeklyAiAnalysis> analysisOpt = weeklyAiAnalysisRepository
-                .findByUserUserIdAndWeekStartDate(userId, currentWeekMonday);
+                .findByUserUserIdAndWeekStartDate(userId, weekStartDate);
 
         if (analysisOpt.isEmpty()) {
             String defaultTitle = hasMissionData

--- a/src/test/java/com/omteam/omt/report/service/MonthlyPatternServiceTest.java
+++ b/src/test/java/com/omteam/omt/report/service/MonthlyPatternServiceTest.java
@@ -3,6 +3,7 @@ package com.omteam.omt.report.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import com.omteam.omt.common.util.DateRangeUtils;
 import com.omteam.omt.mission.domain.DailyMissionResult;
 import com.omteam.omt.mission.domain.Mission;
 import com.omteam.omt.mission.domain.MissionResult;
@@ -62,7 +63,7 @@ class MonthlyPatternServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId);
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, null, null, null);
 
             // then
             assertThat(response.dayOfWeekStats()).hasSize(7);
@@ -72,7 +73,7 @@ class MonthlyPatternServiceTest {
         }
 
         @Test
-        @DisplayName("30일 기간이 올바르게 설정됨")
+        @DisplayName("파라미터 없이 호출 시 이번 주 월요일 기준으로 30일 기간이 설정됨")
         void periodIsSetTo30Days() {
             // given
             given(missionResultRepository.findByUserUserIdAndMissionDateBetweenOrderByMissionDateDesc(
@@ -82,11 +83,12 @@ class MonthlyPatternServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId);
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, null, null, null);
 
             // then
-            assertThat(response.endDate()).isEqualTo(LocalDate.now());
-            assertThat(response.startDate()).isEqualTo(LocalDate.now().minusDays(30));
+            LocalDate expectedEnd = DateRangeUtils.getWeekStartDate(LocalDate.now());
+            assertThat(response.endDate()).isEqualTo(expectedEnd);
+            assertThat(response.startDate()).isEqualTo(expectedEnd.minusDays(30));
         }
 
         @Test
@@ -100,7 +102,7 @@ class MonthlyPatternServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId);
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, null, null, null);
 
             // then
             assertThat(response.dayOfWeekStats()).hasSize(7);
@@ -110,6 +112,25 @@ class MonthlyPatternServiceTest {
             assertThat(response.dayOfWeekStats().stream()
                     .filter(s -> s.dayOfWeek() == DayOfWeek.SUNDAY)
                     .findFirst().get().dayName()).isEqualTo("일요일");
+        }
+
+        @Test
+        @DisplayName("year/month/weekOfMonth 지정 시 해당 주 월요일 기준으로 30일 기간이 설정됨")
+        void periodIsSetBasedOnSpecifiedWeek() {
+            // given: 2024년 1월 3번째 주 월요일 = 2024-01-15
+            given(missionResultRepository.findByUserUserIdAndMissionDateBetweenOrderByMissionDateDesc(
+                    eq(userId), any(), any()))
+                    .willReturn(List.of());
+            given(weeklyAiAnalysisRepository.findByUserUserIdAndWeekStartDate(eq(userId), any()))
+                    .willReturn(Optional.empty());
+
+            // when
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, 2024, 1, 3);
+
+            // then
+            LocalDate expectedEnd = LocalDate.of(2024, 1, 15);
+            assertThat(response.endDate()).isEqualTo(expectedEnd);
+            assertThat(response.startDate()).isEqualTo(expectedEnd.minusDays(30));
         }
     }
 
@@ -138,7 +159,7 @@ class MonthlyPatternServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId);
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, null, null, null);
 
             // then
             MonthlyPatternResponse.DayOfWeekStatistics mondayStats = response.dayOfWeekStats().stream()
@@ -179,7 +200,7 @@ class MonthlyPatternServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId);
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, null, null, null);
 
             // then
             MonthlyPatternResponse.DayOfWeekStatistics mondayStats = response.dayOfWeekStats().stream()
@@ -204,7 +225,7 @@ class MonthlyPatternServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId);
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, null, null, null);
 
             // then
             assertThat(response.aiFeedback().dayOfWeekFeedbackTitle())
@@ -234,7 +255,7 @@ class MonthlyPatternServiceTest {
                     .willReturn(Optional.of(analysis));
 
             // when
-            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId);
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, null, null, null);
 
             // then
             assertThat(response.aiFeedback().dayOfWeekFeedbackTitle()).isEqualTo("화요일에 집중해보세요");
@@ -259,7 +280,7 @@ class MonthlyPatternServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId);
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, null, null, null);
 
             // then
             assertThat(response.aiFeedback().dayOfWeekFeedbackTitle())
@@ -281,7 +302,7 @@ class MonthlyPatternServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId);
+            MonthlyPatternResponse response = monthlyPatternService.getMonthlyPattern(userId, null, null, null);
 
             // then
             assertThat(response.aiFeedback().dayOfWeekFeedbackTitle())


### PR DESCRIPTION
## 관련 이슈
closes #121

## 변경 내용

### `GET /api/reports/monthly-pattern` 파라미터 추가

| 파라미터 | 타입 | 필수 | 설명 |
|---|---|---|---|
| `year` | Integer | X | 연도 |
| `month` | Integer | X | 월 (1-12) |
| `weekOfMonth` | Integer | X | 해당 월의 주차 (1~) |

- 세 파라미터 **모두 null** → 이번 주 기준 (기존 동작 유지)
- 세 파라미터 **모두 지정** → 해당 주 월요일 기준 직전 30일 데이터 + AI 피드백

### 구현 방식

`WeeklyReportService.resolveWeekStartDate()`와 동일한 패턴 적용
```
resolveWeekStartDate(year, month, weekOfMonth)
  → null이면: DateRangeUtils.getWeekStartDate(LocalDate.now())
  → 지정 시:  DateRangeUtils.getWeekStartOfMonth(year, month, weekOfMonth)
```

## 테스트

- 기존 테스트: 새 메서드 시그니처에 맞게 `(userId, null, null, null)` 업데이트
- `periodIsSetTo30Days`: endDate 기준을 `LocalDate.now()` → `이번 주 월요일`로 수정
- 신규 테스트: 특정 주 지정 시 날짜 범위 검증 (`2024/1/3주차 → endDate=2024-01-15`)

## 체크리스트

- [x] 파라미터 미입력 시 기존 동작과 동일
- [x] 잘못된 주차 입력 시 `BusinessException(INVALID_WEEK_OF_MONTH)` 처리 (DateRangeUtils 기존 로직)
- [x] 테스트 통과 (`./gradlew test`)